### PR TITLE
NSApplication.effectiveAppearance must be used from main thread only

### DIFF
--- a/app/modules/serviceInterfaces/HighlighterServiceInterface/Sources/HighlighterService.swift
+++ b/app/modules/serviceInterfaces/HighlighterServiceInterface/Sources/HighlighterService.swift
@@ -13,6 +13,10 @@ public protocol HighlighterServiceProviding {
 }
 
 extension HighlightColors {
+  
+  /// Provides theme-aware syntax highlighting colors based on system appearance.
+  /// @MainActor ensures thread safety when accessing NSAppearance APIs.
+  @MainActor
   public static var codeHighlight: HighlightColors {
     let isDarkMode = NSAppearance.currentDrawing().bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     if isDarkMode {


### PR DESCRIPTION
What do you think if we wrap this in a MAinActor?


This is accessed from  queues, we need to make sure this is accessed form Main thread, I noticed the callers already use `await` 

e.g:

```swift
    let formatterDiff = try await FileDiff.getColoredDiff(
        oldContent: oldContent,
        newContent: newContent,
        highlightColors: .codeHighlight)
```

### Error:

![Screenshot 2025-06-03 at 12 25 49 AM](https://github.com/user-attachments/assets/5512c52e-fabf-4d17-81b3-728a782513cf)
![Screenshot 2025-06-03 at 12 25 59 AM](https://github.com/user-attachments/assets/16a7965f-1773-4a0c-955c-bc7d8246f1a5)
```
Main Thread Checker: UI API called on a background thread: -[NSApplication effectiveAppearance]
PID: 76693, TID: 2511434, Thread name: (none), Queue name: com.apple.root.user-initiated-qos.cooperative, QoS: 25
Backtrace:
5   command (Debug).debug.dylib         0x0000000109a60e54 $s14HighlightSwift0A6ColorsV27HighlighterServiceInterfaceE04codeA0ACvgZ + 44
6   command (Debug).debug.dylib         0x0000000109aad778 $s11CodePreview17FileDiffViewModelC8filePath7changes10oldContentACSgSS_Say0cD10Foundation0cD0O13SearchReplaceVGSSSgtcfcAC16SuggestionUpdate33_2C85B556593B9E8BF4D9F1B198187639LLVSgyYaYbKcfU_TY0_ + 48
7   libswift_Concurrency.dylib          0x000000026c6bb454 _ZN5swift34runJobInEstablishedExecutorContextEPNS_3JobE + 248
8   libswift_Concurrency.dylib          0x000000026c6bc9b4 _ZL17swift_job_runImplPN5swift3JobENS_17SerialExecutorRefE + 156
9   libdispatch.dylib                   0x0000000104e6a30c _dispatch_root_queue_drain + 392
10  libdispatch.dylib                   0x0000000104e6ae2c _dispatch_worker_thread2 + 188
11  libsystem_pthread.dylib             0x0000000104d9b768 _pthread_wqthread + 232
12  libsystem_pthread.dylib             0x0000000104da2f48 start_wqthread + 8
```