### PR TITLE
Making tool description visible

### DIFF
--- a/app/modules/features/Chat/Sources/Message/ChatMessageView+Previews.swift
+++ b/app/modules/features/Chat/Sources/Message/ChatMessageView+Previews.swift
@@ -44,6 +44,7 @@ struct TestTool: NonStreamableTool {
   var name: String { "TestTool" }
   var displayName: String { "Test Tool" }
   var description: String { "A tool for testing." }
+  var shortDescription: String { description }
 
   func use(toolUseId _: String, input _: String, context _: ToolExecutionContext) -> Use {
     Use()

--- a/app/modules/features/Settings/Sources/ToolsConfigurationView.swift
+++ b/app/modules/features/Settings/Sources/ToolsConfigurationView.swift
@@ -53,8 +53,8 @@ private struct ToolRow: View {
       VStack(alignment: .leading, spacing: 4) {
         Text(tool.displayName)
           .font(.system(size: 13, weight: .medium))
-        if !tool.description.isEmpty {
-          Text(tool.description)
+        if !tool.shortDescription.isEmpty {
+          Text(tool.shortDescription)
             .font(.system(size: 11))
             .foregroundColor(.secondary)
         }

--- a/app/modules/foundations/ToolFoundation/Sources/Tool.swift
+++ b/app/modules/foundations/ToolFoundation/Sources/Tool.swift
@@ -30,6 +30,8 @@ public protocol Tool: Sendable {
   var canInputBeStreamed: Bool { get }
   /// The tool display name
   var displayName: String { get }
+  /// A short description of the tool (max 3 lines)
+  var shortDescription: String { get }
 }
 
 extension Tool {

--- a/app/modules/plugins/tools/AskFollowUpTool/Sources/AskFollowUpTool.swift
+++ b/app/modules/plugins/tools/AskFollowUpTool/Sources/AskFollowUpTool.swift
@@ -72,6 +72,10 @@ public final class AskFollowUpTool: NonStreamableTool {
     "Follow Up"
   }
 
+  public var shortDescription: String {
+    "Asks the user a clarifying question with suggested follow-up options."
+  }
+
   public var inputSchema: JSON {
     .object([
       "type": .string("object"),

--- a/app/modules/plugins/tools/BuildTool/Sources/BuildTool.swift
+++ b/app/modules/plugins/tools/BuildTool/Sources/BuildTool.swift
@@ -99,6 +99,10 @@ public final class BuildTool: NonStreamableTool {
     "Build"
   }
 
+  public var shortDescription: String {
+    "Triggers Xcode build actions for testing or running and provides output results."
+  }
+
   public var inputSchema: JSON {
     .object([
       "type": .string("object"),

--- a/app/modules/plugins/tools/EditFilesTool/Sources/EditFilesTool.swift
+++ b/app/modules/plugins/tools/EditFilesTool/Sources/EditFilesTool.swift
@@ -293,7 +293,7 @@ public final class EditFilesTool: Tool {
 
   private let shouldAutoApply: Bool
 
-  private var shortDescription: String {
+  public var shortDescription: String {
     if shouldAutoApply {
       "Replace existing code using search/replace blocks in a list of files and create new files."
     } else {

--- a/app/modules/plugins/tools/ExecuteCommandTool/Sources/ExecuteCommandTool.swift
+++ b/app/modules/plugins/tools/ExecuteCommandTool/Sources/ExecuteCommandTool.swift
@@ -136,6 +136,10 @@ public final class ExecuteCommandTool: NonStreamableTool {
     "Execute Command"
   }
 
+  public var shortDescription: String {
+    "Executes CLI commands on the system for operations, builds, and tests."
+  }
+
   public var inputSchema: JSON {
     .object([
       "type": .string("object"),

--- a/app/modules/plugins/tools/LSTool/Sources/LSTool.swift
+++ b/app/modules/plugins/tools/LSTool/Sources/LSTool.swift
@@ -107,6 +107,10 @@ public final class LSTool: NonStreamableTool {
     "List Files"
   }
 
+  public var shortDescription: String {
+    "Lists files and directories within a specified directory, optionally recursive."
+  }
+
   public var inputSchema: JSON {
     .object([
       "type": .string("object"),

--- a/app/modules/plugins/tools/ReadFileTool/Sources/ReadFileTool.swift
+++ b/app/modules/plugins/tools/ReadFileTool/Sources/ReadFileTool.swift
@@ -99,6 +99,10 @@ public final class ReadFileTool: NonStreamableTool {
     "Read File"
   }
 
+  public var shortDescription: String {
+    "Reads the content of a file, optionally limiting to a specific line range."
+  }
+
   public var inputSchema: JSON {
     .object([
       "type": .string("object"),

--- a/app/modules/plugins/tools/SearchFilesTool/Sources/SearchFilesTool.swift
+++ b/app/modules/plugins/tools/SearchFilesTool/Sources/SearchFilesTool.swift
@@ -104,6 +104,10 @@ public final class SearchFilesTool: NonStreamableTool {
     "Search Files"
   }
 
+  public var shortDescription: String {
+    "Performs regex search across files in a directory, returning matches with context."
+  }
+
   public var inputSchema: JSON {
     .object([
       "type": .string("object"),

--- a/app/modules/services/LLMService/Sources/FailedTool.swift
+++ b/app/modules/services/LLMService/Sources/FailedTool.swift
@@ -52,6 +52,10 @@ struct FailedTool: NonStreamableTool {
     "Failed tool"
   }
 
+  var shortDescription: String {
+    "Placeholder for tools that failed to execute properly."
+  }
+
   var description: String { "Failed tool" }
   var inputSchema: JSON { .object([:]) }
 


### PR DESCRIPTION
I am not sure if this is what we want?

![Screenshot 2025-06-06 at 12 14 59 AM](https://github.com/user-attachments/assets/4ae9e49f-1831-4023-82a4-bc4796971bd7)

alternatives:

- Have a short description in the `Tool` protocol
- Make this rows show 3 lines or some height and then allow expand/collapse.