### PR TITLE
Run streamed tool with non streamed input

### DIFF
--- a/app/modules/services/LLMService/Tests/APIsSerializationTests.swift
+++ b/app/modules/services/LLMService/Tests/APIsSerializationTests.swift
@@ -179,8 +179,8 @@ struct APIParamsEncodingTests {
     let settingsService = MockSettingsService(.init(
       pointReleaseXcodeExtensionToDebugApp: false,
       llmProviderSettings: [
-        .openAI: LLMProviderSettings(
-          apiKey: "openai-key",
+        .anthropic: LLMProviderSettings(
+          apiKey: "anthropic-key",
           baseUrl: nil,
           createdOrder: 2),
       ],


### PR DESCRIPTION
When using a tool that supports input streaming (like the file edit tool), run the tool from the atomic input that we received after all the input chunks have been received, instead of one "tic" earlier once we've been able to put all the chunked input back to a valid JSON.

I've run into some rare issues where the file edit was corrupted. I'm wondering if there's not a racing issue somewhere that would cause some chunks to be parsed out of order despite existing guardrails (eg each chunk has an index between our local node js server and the app). But anyway running the tool out of the full input sent in one `tool_call` chunk seems more reliable and has little downside (we do one more parsing)