### PR TITLE
File edit mode: disk vs Xcode extension

### DIFF
--- a/app/modules/Package.swift
+++ b/app/modules/Package.swift
@@ -865,7 +865,19 @@ targets.append(contentsOf: Target.module(
     "XcodeControllerServiceInterface",
     "XcodeObserverServiceInterface",
   ],
-  testDependencies: [],
+  testDependencies: [
+    "AppEventServiceInterface",
+    "AppFoundation",
+    "ExtensionEventsInterface",
+    "FileDiffFoundation",
+    "FoundationInterfaces",
+    "SettingsServiceInterface",
+    "SharedValuesFoundation",
+    "ShellServiceInterface",
+    "SwiftTesting",
+    "XcodeControllerServiceInterface",
+    "XcodeObserverServiceInterface",
+  ],
   path: "./services/XcodeControllerService"))
 
 targets.append(contentsOf: Target.module(

--- a/app/modules/coreui/DLS/Sources/Colors.swift
+++ b/app/modules/coreui/DLS/Sources/Colors.swift
@@ -79,7 +79,7 @@ extension ColorScheme {
 
   // TODO: this depends on the theme used in Xcode.
   // The current color schema can be read with `defaults read ~/Library/Preferences/com.apple.dt.Xcode | grep XCFontAndColorCurrent`
-  // also contains indentation info, path to the detault app (eg file:///Applications/Xcode-16.2.0.app/),
+  // also contains indentation info, path to the default app (eg file:///Applications/Xcode-16.2.0.app/),
   // key binding
   public var xcodeEditorBackground: Color {
     self == .dark ? Color(red: 41.0 / 255, green: 42.0 / 255, blue: 48.0 / 255) : .white

--- a/app/modules/features/SettingsFeature/Sources/AboutSettingsView+Previews.swift
+++ b/app/modules/features/SettingsFeature/Sources/AboutSettingsView+Previews.swift
@@ -8,7 +8,7 @@ import SwiftUI
 #Preview("About Settings - Analytics Enabled") {
   AboutSettingsView(
     allowAnonymousAnalytics: .constant(true),
-    automaticallyCheckForUpdates: .constant(true))
+    automaticallyCheckForUpdates: .constant(true), fileEditMode: .constant(.xcodeExtension))
     .frame(width: 600, height: 400)
     .padding()
 }
@@ -16,7 +16,7 @@ import SwiftUI
 #Preview("About Settings - Analytics Disabled") {
   AboutSettingsView(
     allowAnonymousAnalytics: .constant(false),
-    automaticallyCheckForUpdates: .constant(false))
+    automaticallyCheckForUpdates: .constant(false), fileEditMode: .constant(.directIO))
     .frame(width: 600, height: 400)
     .padding()
 }

--- a/app/modules/features/SettingsFeature/Sources/AboutSettingsView.swift
+++ b/app/modules/features/SettingsFeature/Sources/AboutSettingsView.swift
@@ -4,6 +4,7 @@
 import AppUpdateServiceInterface
 import Dependencies
 import DLS
+import SettingsServiceInterface
 import SwiftUI
 
 // MARK: - AboutSettingsView
@@ -11,6 +12,7 @@ import SwiftUI
 struct AboutSettingsView: View {
   @Binding var allowAnonymousAnalytics: Bool
   @Binding var automaticallyCheckForUpdates: Bool
+  @Binding var fileEditMode: FileEditMode
 
   var body: some View {
     VStack(alignment: .leading, spacing: 24) {
@@ -79,12 +81,75 @@ struct AboutSettingsView: View {
             .stroke(Color.gray.opacity(0.2), lineWidth: 1))
       }
 
+      // File Edit Mode Section
+      VStack(alignment: .leading, spacing: 16) {
+        Text("File Editing")
+          .font(.headline)
+
+        VStack(alignment: .leading, spacing: 16) {
+          Text("File Edit Mode")
+            .fontWeight(.medium)
+
+          VStack(spacing: 12) {
+            ForEach(FileEditMode.allCases, id: \.self) { mode in
+              HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                  Text(mode.rawValue)
+                    .fontWeight(.medium)
+                  Text(mode.description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+                Spacer()
+                RadioButton(isSelected: fileEditMode == mode) {
+                  fileEditMode = mode
+                }
+              }
+              .contentShape(Rectangle())
+              .onTapGesture {
+                fileEditMode = mode
+              }
+            }
+          }
+        }
+        .padding(16)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .overlay(
+          RoundedRectangle(cornerRadius: 8)
+            .stroke(Color.gray.opacity(0.2), lineWidth: 1))
+      }
+
       Spacer()
     }
   }
 
   @Dependency(\.appUpdateService) private var appUpdateService: AppUpdateService
 
+}
+
+// MARK: - RadioButton
+
+private struct RadioButton: View {
+  let isSelected: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      ZStack {
+        Circle()
+          .stroke(Color.secondary, lineWidth: 2)
+          .frame(width: 16, height: 16)
+
+        if isSelected {
+          Circle()
+            .fill(Color.accentColor)
+            .frame(width: 8, height: 8)
+        }
+      }
+    }
+    .buttonStyle(PlainButtonStyle())
+  }
 }
 
 // MARK: - InfoRow

--- a/app/modules/features/SettingsFeature/Sources/SettingsView.swift
+++ b/app/modules/features/SettingsFeature/Sources/SettingsView.swift
@@ -110,7 +110,8 @@ public struct SettingsView: View {
       case .about:
         AboutSettingsView(
           allowAnonymousAnalytics: $viewModel.allowAnonymousAnalytics,
-          automaticallyCheckForUpdates: $viewModel.automaticallyCheckForUpdates)
+          automaticallyCheckForUpdates: $viewModel.automaticallyCheckForUpdates,
+          fileEditMode: $viewModel.fileEditMode)
 
       case .landing:
         EmptyView()

--- a/app/modules/features/SettingsFeature/Sources/SettingsViewModel.swift
+++ b/app/modules/features/SettingsFeature/Sources/SettingsViewModel.swift
@@ -79,6 +79,16 @@ public final class SettingsViewModel {
     }
   }
 
+  var fileEditMode: FileEditMode {
+    get {
+      settings.fileEditMode
+    }
+    set {
+      settings.fileEditMode = newValue
+      settingsService.update(setting: \.fileEditMode, to: newValue)
+    }
+  }
+
   // MARK: - Internal settings
   var repeatLastLLMInteraction: Bool {
     didSet {

--- a/app/modules/features/SettingsFeature/Tests/SettingsViewModelTests.swift
+++ b/app/modules/features/SettingsFeature/Tests/SettingsViewModelTests.swift
@@ -167,6 +167,29 @@ struct SettingsViewModelTests {
     #expect(mockSettingsService.value(for: \.pointReleaseXcodeExtensionToDebugApp) == true)
   }
 
+  @Test("fileEditMode setter updates settings service")
+  func test_fileEditMode_setter() {
+    let mockSettingsService = MockSettingsService()
+    let mockUserDefaults = MockUserDefaults()
+
+    let viewModel = withDependencies {
+      $0.settingsService = mockSettingsService
+      $0.userDefaults = mockUserDefaults
+    } operation: {
+      SettingsViewModel()
+    }
+
+    // Test setting to direct I/O
+    viewModel.fileEditMode = .directIO
+    #expect(viewModel.fileEditMode == .directIO)
+    #expect(mockSettingsService.value(for: \.fileEditMode) == .directIO)
+
+    // Test setting to Xcode extension
+    viewModel.fileEditMode = .xcodeExtension
+    #expect(viewModel.fileEditMode == .xcodeExtension)
+    #expect(mockSettingsService.value(for: \.fileEditMode) == .xcodeExtension)
+  }
+
   @Test("observes live settings updates")
   func test_liveSettingsUpdates() async throws {
     let mockSettingsService = MockSettingsService()

--- a/app/modules/foundations/FoundationInterfaces/Sources/FileManager+Mock.swift
+++ b/app/modules/foundations/FoundationInterfaces/Sources/FileManager+Mock.swift
@@ -162,7 +162,7 @@ public final class MockFileManager: FileManagerI {
 
   // We use URL as keys to support file properties.
   // Since URL are reference types, for most functions we need to compare path instead of references. Those helpers help do this.
-    
+
   private func read(_ path: URL) -> Data? {
     files[self.path(matching: path)]
   }

--- a/app/modules/foundations/FoundationInterfaces/Sources/FileManager+Mock.swift
+++ b/app/modules/foundations/FoundationInterfaces/Sources/FileManager+Mock.swift
@@ -42,25 +42,25 @@ public final class MockFileManager: FileManagerI {
   }
 
   public func read(contentsOf url: URL, encoding _: String.Encoding) throws -> String {
-    guard let content = files[url]?.asString else {
+    guard let content = read(url)?.asString else {
       throw NSError(domain: CocoaError.errorDomain, code: CocoaError.fileNoSuchFile.rawValue)
     }
     return content
   }
 
   public func read(dataFrom url: URL) throws -> Data {
-    guard let content = files[url] else {
+    guard let content = read(url) else {
       throw NSError(domain: CocoaError.errorDomain, code: CocoaError.fileNoSuchFile.rawValue)
     }
     return content
   }
 
   public func write(data: Data, to url: URL, options _: Data.WritingOptions) throws {
-    inLock { $0.files[url] = data }
+    set(url, to: data)
   }
 
   public func write(string: String, to url: URL, options _: Data.WritingOptions) throws {
-    inLock { $0.files[url] = string.asData }
+    set(url, to: string.asData)
   }
 
   public func createDirectory(
@@ -106,15 +106,15 @@ public final class MockFileManager: FileManagerI {
   }
 
   public func copyItem(atPath srcPath: String, toPath dstPath: String) throws {
-    inLock { $0.files[URL(fileURLWithPath: dstPath)] = $0.files[URL(fileURLWithPath: srcPath)] }
+    inLock { $0.files[path(matching: dstPath)] = $0.files[path(matching: srcPath)] }
   }
 
   public func removeItem(atPath path: String) throws {
-    inLock { $0.files[URL(fileURLWithPath: path)] = nil }
+    inLock { $0.files[self.path(matching: path)] = nil }
   }
 
   public func fileExists(atPath path: String) -> Bool {
-    files[URL(fileURLWithPath: path)] != nil
+    files[self.path(matching: path)] != nil
   }
 
   public func contentsOfDirectory(
@@ -160,6 +160,24 @@ public final class MockFileManager: FileManagerI {
   private(set) var files = [URL: Data]()
   private(set) var directories = [URL]()
 
+  // We use URL as keys to support file properties.
+  // Since URL are reference types, for most functions we need to compare path instead of references. Those helpers help do this.
+    
+  private func read(_ path: URL) -> Data? {
+    files[self.path(matching: path)]
+  }
+
+  private func set(_ path: URL, to content: Data?) {
+    files[self.path(matching: path)] = content
+  }
+
+  private func path(matching url: URL) -> URL {
+    files.keys.first { $0.path == url.path } ?? url
+  }
+
+  private func path(matching url: String) -> URL {
+    path(matching: URL(fileURLWithPath: url))
+  }
 }
 
 // MARK: - MockDirectoryEnumerator

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
@@ -49,7 +49,7 @@ public struct Settings: Sendable, Equatable {
     pointReleaseXcodeExtensionToDebugApp: Bool,
     allowAnonymousAnalytics: Bool = false,
     automaticallyCheckForUpdates: Bool = true,
-    fileEditMode: FileEditMode = .xcodeExtension,
+    fileEditMode: FileEditMode = .directIO,
     preferedProviders: [LLMModel: LLMProvider] = [:],
     llmProviderSettings: [LLMProvider: LLMProviderSettings] = [:],
     inactiveModels: [LLMModel] = [],

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
@@ -8,6 +8,31 @@ import Foundation
 import JSONFoundation
 import LLMFoundation
 
+// MARK: - FileEditMode
+
+public enum FileEditMode: String, Sendable, Codable, Equatable, CaseIterable {
+  case directIO = "direct I/O"
+  case xcodeExtension = "Xcode Extension"
+
+  public var description: String {
+    switch self {
+    case .directIO:
+      """
+      Direct I/O - Modify files directly on disk.
+      + simplest and non disruptive.
+      - does not work with unsaved changes in Xcode, and does not maintain edit history.
+      """
+
+    case .xcodeExtension:
+      """
+      Xcode Extension - Modify the file through Xcode.
+      + consistent with unsaved changes and maintain edit history.
+      - activate Xcode and bring the file in focus, which can be disruptive.
+      """
+    }
+  }
+}
+
 // MARK: - LLMReasoningSetting
 
 public struct LLMReasoningSetting: Sendable, Equatable {
@@ -24,6 +49,7 @@ public struct Settings: Sendable, Equatable {
     pointReleaseXcodeExtensionToDebugApp: Bool,
     allowAnonymousAnalytics: Bool = false,
     automaticallyCheckForUpdates: Bool = true,
+    fileEditMode: FileEditMode = .xcodeExtension,
     preferedProviders: [LLMModel: LLMProvider] = [:],
     llmProviderSettings: [LLMProvider: LLMProviderSettings] = [:],
     inactiveModels: [LLMModel] = [],
@@ -34,6 +60,7 @@ public struct Settings: Sendable, Equatable {
     self.pointReleaseXcodeExtensionToDebugApp = pointReleaseXcodeExtensionToDebugApp
     self.allowAnonymousAnalytics = allowAnonymousAnalytics
     self.automaticallyCheckForUpdates = automaticallyCheckForUpdates
+    self.fileEditMode = fileEditMode
     self.preferedProviders = preferedProviders
     self.llmProviderSettings = llmProviderSettings
     self.inactiveModels = inactiveModels
@@ -83,6 +110,7 @@ public struct Settings: Sendable, Equatable {
   public var allowAnonymousAnalytics: Bool
   public var pointReleaseXcodeExtensionToDebugApp: Bool
   public var automaticallyCheckForUpdates: Bool
+  public var fileEditMode: FileEditMode
   // LLM settings
   public var preferedProviders: [LLMModel: LLMProvider]
   public var llmProviderSettings: [LLMProvider: LLMProviderSettings]

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Tests/SettingsService+MockTests.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Tests/SettingsService+MockTests.swift
@@ -171,4 +171,59 @@ struct SettingsServiceMockTests {
     #expect(receivedSettings[1].pointReleaseXcodeExtensionToDebugApp == true)
     #expect(receivedSettings[2].pointReleaseXcodeExtensionToDebugApp == false)
   }
+
+  @Test("FileEditMode setting in Settings")
+  func test_fileEditModeSetting() {
+    // Test default value
+    let defaultSettings = Settings(pointReleaseXcodeExtensionToDebugApp: false)
+    #expect(defaultSettings.fileEditMode == .xcodeExtension)
+
+    // Test with custom value
+    let customSettings = Settings(
+      pointReleaseXcodeExtensionToDebugApp: false,
+      fileEditMode: .directIO)
+    #expect(customSettings.fileEditMode == .directIO)
+
+    // Test with MockSettingsService
+    let sut = MockSettingsService(defaultSettings: customSettings)
+    #expect(sut.value(for: \.fileEditMode) == .directIO)
+
+    // Test updating the setting
+    sut.update(setting: \.fileEditMode, to: .xcodeExtension)
+    #expect(sut.value(for: \.fileEditMode) == .xcodeExtension)
+  }
+
+  @Test("FileEditMode live updates")
+  func test_fileEditModeLiveUpdates() async throws {
+    let initialSettings = Settings(
+      pointReleaseXcodeExtensionToDebugApp: false,
+      fileEditMode: .xcodeExtension)
+    let sut = MockSettingsService(defaultSettings: initialSettings)
+
+    var cancellables = Set<AnyCancellable>()
+    var receivedModes: [FileEditMode] = []
+    let modesReceived = expectation(description: "File edit modes received")
+
+    sut.liveValue(for: \.fileEditMode)
+      .sink { mode in
+        receivedModes.append(mode)
+        if receivedModes.count == 3 {
+          modesReceived.fulfill()
+        }
+      }
+      .store(in: &cancellables)
+
+    // Initial value should be received
+    #expect(receivedModes.count == 1)
+    #expect(receivedModes.first == .xcodeExtension)
+
+    // Update to direct I/O
+    sut.update(setting: \.fileEditMode, to: .directIO)
+
+    // Reset to default
+    sut.resetToDefault(setting: \.fileEditMode)
+
+    try await fulfillment(of: [modesReceived])
+    #expect(receivedModes == [.xcodeExtension, .directIO, .xcodeExtension])
+  }
 }

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Tests/SettingsService+MockTests.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Tests/SettingsService+MockTests.swift
@@ -186,7 +186,7 @@ struct SettingsServiceMockTests {
 
     // Test with MockSettingsService
     let sut = MockSettingsService(defaultSettings: customSettings)
-    #expect(sut.value(for: \.fileEditMode) == .directIO)
+    #expect(sut.value(for: \.fileEditMode) == .xcodeExtension)
 
     // Test updating the setting
     sut.update(setting: \.fileEditMode, to: .xcodeExtension)

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Tests/SettingsService+MockTests.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Tests/SettingsService+MockTests.swift
@@ -176,13 +176,13 @@ struct SettingsServiceMockTests {
   func test_fileEditModeSetting() {
     // Test default value
     let defaultSettings = Settings(pointReleaseXcodeExtensionToDebugApp: false)
-    #expect(defaultSettings.fileEditMode == .xcodeExtension)
+    #expect(defaultSettings.fileEditMode == .directIO)
 
     // Test with custom value
     let customSettings = Settings(
       pointReleaseXcodeExtensionToDebugApp: false,
-      fileEditMode: .directIO)
-    #expect(customSettings.fileEditMode == .directIO)
+      fileEditMode: .xcodeExtension)
+    #expect(customSettings.fileEditMode == .xcodeExtension)
 
     // Test with MockSettingsService
     let sut = MockSettingsService(defaultSettings: customSettings)

--- a/app/modules/services/ChatHistoryService/Sources/DefaultChatHistoryService.swift
+++ b/app/modules/services/ChatHistoryService/Sources/DefaultChatHistoryService.swift
@@ -174,14 +174,14 @@ extension BaseProviding where
         createDBConnection: {
           do {
             // Create database directory if it doesn't exist
-            let documentsURLs = fileManager.urls(for: .documentDirectory, in: .userDomainMask)
+            let documentsURLs = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
             guard let documentsURL = documentsURLs.first else {
               throw NSError(
                 domain: "ChatDatabaseService",
                 code: 1,
                 userInfo: [NSLocalizedDescriptionKey: "Could not find documents directory"])
             }
-            let chatDataURL = documentsURL.appendingPathComponent("ChatData")
+            let chatDataURL = documentsURL.appendingPathComponent("\(Bundle.main.hostAppBundleId)/ChatData")
 
             if !fileManager.fileExists(atPath: chatDataURL.path) {
               try fileManager.createDirectory(

--- a/app/modules/services/SettingsService/Sources/Settings+Codable.swift
+++ b/app/modules/services/SettingsService/Sources/Settings+Codable.swift
@@ -15,6 +15,7 @@ extension Settings: Codable {
         .decodeIfPresent(Bool.self, forKey: "pointReleaseXcodeExtensionToDebugApp") ?? false,
       allowAnonymousAnalytics: container.decodeIfPresent(Bool.self, forKey: "allowAnonymousAnalytics") ?? true,
       automaticallyCheckForUpdates: container.decodeIfPresent(Bool.self, forKey: "automaticallyCheckForUpdates") ?? true,
+      fileEditMode: container.decodeIfPresent(FileEditMode.self, forKey: "fileEditMode") ?? .directIO,
       preferedProviders: container.decodeIfPresent([String: String].self, forKey: "preferedProviders")?
         .reduce(into: [LLMModel: LLMProvider]()) { acc, el in
           guard let model = LLMModel(rawValue: el.key), let provider = LLMProvider(rawValue: el.value) else { return }
@@ -46,6 +47,7 @@ extension Settings: Codable {
     try container.encode(pointReleaseXcodeExtensionToDebugApp, forKey: "pointReleaseXcodeExtensionToDebugApp")
     try container.encode(allowAnonymousAnalytics, forKey: "allowAnonymousAnalytics")
     try container.encode(automaticallyCheckForUpdates, forKey: "automaticallyCheckForUpdates")
+    try container.encode(fileEditMode, forKey: "fileEditMode")
     try container.encode(preferedProviders.reduce(into: [String: String]()) { acc, el in
       acc[el.key.rawValue] = el.value.rawValue
     }, forKey: "preferedProviders")

--- a/app/modules/services/SettingsService/Tests/DefaultSettingsServiceTests.swift
+++ b/app/modules/services/SettingsService/Tests/DefaultSettingsServiceTests.swift
@@ -260,7 +260,8 @@ struct DefaultSettingsServiceTests {
         "preferedProviders" : {},
         "reasoningModels" : {},
         "inactiveModels" : [],
-        "toolPreferences" : []
+        "toolPreferences" : [],
+        "fileEditMode": "direct I/O" 
       }
       """)
     _ = cancellable

--- a/app/modules/services/SettingsService/Tests/Settings+CodableTests.swift
+++ b/app/modules/services/SettingsService/Tests/Settings+CodableTests.swift
@@ -34,7 +34,8 @@ struct SettingsCodableTests {
           "claude-haiku-35" : "anthropic",
           "gpt-4o" : "openai"
         },
-        "reasoningModels": {}
+        "reasoningModels": {},
+        "fileEditMode": "direct I/O" 
       }
       """
 
@@ -71,7 +72,8 @@ struct SettingsCodableTests {
         },
         "pointReleaseXcodeExtensionToDebugApp" : false,
         "preferedProviders" : {},
-        "reasoningModels": {}
+        "reasoningModels": {},
+        "fileEditMode": "direct I/O" 
       }
       """
 
@@ -122,7 +124,8 @@ struct SettingsCodableTests {
         "preferedProviders" : {
           "claude-haiku-35" : "anthropic"
         },
-        "reasoningModels": {}
+        "reasoningModels": {},
+        "fileEditMode": "direct I/O" 
       }
       """
 
@@ -246,7 +249,8 @@ struct SettingsCodableTests {
         "llmProviderSettings" : {},
         "pointReleaseXcodeExtensionToDebugApp" : false,
         "preferedProviders" : {},
-        "reasoningModels": {}
+        "reasoningModels": {},
+        "fileEditMode": "direct I/O" 
       }
       """
 
@@ -284,7 +288,8 @@ struct SettingsCodableTests {
             "isEnabled" : false
           }
         },
-        "toolPreferences": []
+        "toolPreferences": [],
+        "fileEditMode": "direct I/O" 
       }
       """
 
@@ -420,7 +425,8 @@ struct SettingsCodableTests {
         "toolPreferences" : [],
         "pointReleaseXcodeExtensionToDebugApp" : false,
         "preferedProviders" : {},
-        "reasoningModels": {}
+        "reasoningModels": {},
+        "fileEditMode": "direct I/O" 
       }
       """
 
@@ -455,7 +461,8 @@ struct SettingsCodableTests {
         "preferedProviders" : {
           "claude-haiku-35" : "anthropic"
         },
-        "reasoningModels": {}
+        "reasoningModels": {},
+        "fileEditMode": "direct I/O" 
       }
       """
 
@@ -556,7 +563,8 @@ struct SettingsCodableTests {
             "alwaysApprove" : true,
             "toolName" : "ReadFileTool"
           }
-        ]
+        ],
+        "fileEditMode": "direct I/O" 
       }
       """
 

--- a/app/modules/services/XcodeControllerService/Module.swift
+++ b/app/modules/services/XcodeControllerService/Module.swift
@@ -17,4 +17,16 @@ Target.module(
     "XcodeControllerServiceInterface",
     "XcodeObserverServiceInterface",
   ],
-  testDependencies: [])
+  testDependencies: [
+    "AppEventServiceInterface",
+    "AppFoundation",
+    "ExtensionEventsInterface",
+    "FileDiffFoundation",
+    "FoundationInterfaces",
+    "SettingsServiceInterface",
+    "SharedValuesFoundation",
+    "ShellServiceInterface",
+    "SwiftTesting",
+    "XcodeControllerServiceInterface",
+    "XcodeObserverServiceInterface",
+  ])

--- a/app/modules/services/XcodeControllerService/Tests/DetaultXcodeControllerTests.swift
+++ b/app/modules/services/XcodeControllerService/Tests/DetaultXcodeControllerTests.swift
@@ -17,9 +17,9 @@ import XcodeControllerServiceInterface
 import XcodeObserverServiceInterface
 @testable import XcodeControllerService
 
-// MARK: - DetaultXcodeControllerTests
+// MARK: - DefaultXcodeControllerTests
 
-struct DetaultXcodeControllerTests {
+struct DefaultXcodeControllerTests {
 
   @Test("File edit mode setting is respected - Xcode Extension mode")
   func testFileEditModeXcodeExtension() async throws {

--- a/app/modules/services/XcodeControllerService/Tests/DetaultXcodeControllerTests.swift
+++ b/app/modules/services/XcodeControllerService/Tests/DetaultXcodeControllerTests.swift
@@ -1,9 +1,132 @@
 // Copyright cmd app, Inc. Licensed under the Apache License, Version 2.0.
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+import AppEventServiceInterface
+import AppFoundation
+import Dependencies
+import ExtensionEventsInterface
+import FileDiffFoundation
+import Foundation
+import FoundationInterfaces
+import SettingsServiceInterface
+import SharedValuesFoundation
+import ShellServiceInterface
+import SwiftTesting
 import Testing
+import XcodeControllerServiceInterface
+import XcodeObserverServiceInterface
 @testable import XcodeControllerService
 
-// MARK: - DefaultAppServiceTests
+// MARK: - DetaultXcodeControllerTests
 
-struct DetaultXcodeControllerTests { }
+struct DetaultXcodeControllerTests {
+
+  @Test("File edit mode setting is respected - Xcode Extension mode")
+  func testFileEditModeXcodeExtension() async throws {
+    let testFile = URL(filePath: "test_file.swift")
+    let fileContent = "let x = 1"
+    let newContent = "let x = 2"
+
+    let xcodeExtensionTriggered = expectation(description: "Xcode extension has been triggered")
+
+    let mockFileManager = MockFileManager(files: [testFile: fileContent], directories: [])
+
+    let appEventHandlerRegistry = MockAppEventHandlerRegistry()
+
+    let controller = DefaultXcodeController(
+      appEventHandlerRegistry: appEventHandlerRegistry,
+      settingsService: MockSettingsService(Settings(
+        pointReleaseXcodeExtensionToDebugApp: false,
+        fileEditMode: .xcodeExtension)),
+      fileManager: mockFileManager,
+      startApplyingFileChangeWithXcodeExtension: {
+        xcodeExtensionTriggered.fulfill()
+      })
+
+    let fileChange = FileChange(
+      filePath: testFile,
+      oldContent: fileContent,
+      suggestedNewContent: newContent,
+      selectedChange: [],
+      id: "test")
+
+    async let hasApplied: () = controller.apply(fileChange: fileChange)
+
+    // Verify that the extension was triggered
+    try await fulfillment(of: xcodeExtensionTriggered)
+
+    _ = await appEventHandlerRegistry.handle(event: ExecuteExtensionRequestEvent(
+      command: ExtensionCommandKeys.getFileChangeToApply,
+      id: "123",
+      data: Data()) { _ in })
+
+    _ = try await appEventHandlerRegistry.handle(event: ExecuteExtensionRequestEvent(
+      command: ExtensionCommandKeys.confirmFileChangeApplied,
+      id: "123",
+      data: JSONEncoder().encode(ExtensionRequest<FileChangeConfirmation>(
+        command: ExtensionCommandKeys.confirmFileChangeApplied,
+        input: .init(id: "123", error: nil)))) { _ in })
+
+    try await hasApplied
+
+    // Verify that the file system was not otherwise modified
+    let newFileContent = try mockFileManager.read(contentsOf: testFile)
+    assert(newFileContent == fileContent)
+  }
+
+  @Test("File edit mode setting is respected - Direct I/O mode")
+  func testFileEditModeDirectIO() async throws {
+    let testFile = URL(filePath: "test_file.swift")
+    let fileContent = "let x = 1"
+    let newContent = "let x = 2"
+
+    let mockFileManager = MockFileManager(files: [
+      testFile.path: fileContent,
+    ])
+
+    let controller = DefaultXcodeController(
+      settingsService: MockSettingsService(Settings(
+        pointReleaseXcodeExtensionToDebugApp: false,
+        fileEditMode: .directIO)),
+      fileManager: mockFileManager,
+      startApplyingFileChangeWithXcodeExtension: {
+        Issue.record("Xcode extension should not have been triggered")
+      })
+
+    let fileChange = FileChange(
+      filePath: testFile,
+      oldContent: fileContent,
+      suggestedNewContent: newContent,
+      selectedChange: [],
+      id: "test")
+
+    try await controller.apply(fileChange: fileChange)
+
+    // Verify that the file system has been modified on disk
+    let newFileContent = try mockFileManager.read(contentsOf: testFile)
+    assert(newFileContent == newContent)
+  }
+
+}
+
+extension DefaultXcodeController {
+  convenience init(
+    appEventHandlerRegistry: MockAppEventHandlerRegistry = MockAppEventHandlerRegistry(),
+    shellService: MockShellService = MockShellService(),
+    xcodeObserver: MockXcodeObserver = MockXcodeObserver(.unknown),
+    settingsService: MockSettingsService = MockSettingsService(Settings(pointReleaseXcodeExtensionToDebugApp: false)),
+    fileManager: MockFileManager = MockFileManager(files: [:]),
+    timeout: TimeInterval = 10,
+    startApplyingFileChangeWithXcodeExtension: @escaping @Sendable () async throws -> Void = { })
+  {
+    self.init(
+      appEventHandlerRegistry: appEventHandlerRegistry,
+      shellService: shellService,
+      xcodeObserver: xcodeObserver,
+      settingsService: settingsService,
+      fileManager: fileManager,
+      timeout: timeout,
+      canUseAppleScript: false,
+      startApplyingFileChangeWithXcodeExtension: startApplyingFileChangeWithXcodeExtension)
+  }
+}


### PR DESCRIPTION
Support changing files directly on disk that, depending on the workflow, can be less disruptive.

<img width="393" height="286" alt="Screenshot 2025-07-21 at 2 02 36 PM" src="https://github.com/user-attachments/assets/33e57e68-5aad-483c-980f-9125e789a895" />
