### PR TITLE
Update chat context when sending attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 .DS_Store
 secrets.json
-tmp
+tmp/**
 .aider*
 
-.build
-build
+.build/**
+build/**
 .swiftpm
 .serena
 *.tmp
+!.keep

--- a/app/modules/features/Chat/ChatFeature/Sources/ChatThreadViewModel.swift
+++ b/app/modules/features/Chat/ChatFeature/Sources/ChatThreadViewModel.swift
@@ -188,6 +188,14 @@ final class ChatThreadViewModel: Identifiable, Equatable {
     input.textInput = TextInput()
     input.attachments = []
 
+    for attachment in attachments {
+      if case .file(let fileAttachment) = attachment {
+        // The entire content of the attachment is sent to the LLM.
+        // We update the chat context to reflect this, so that the LLM can edit this file without having to first use the read tool.
+        context.set(knownFileContent: fileAttachment.content, for: fileAttachment.path)
+      }
+    }
+
     if !textInput.string.string.isEmpty {
       // TODO: reformat the string sent to the LLM
       let messageContent = ChatMessageContent.text(ChatMessageTextContent(


### PR DESCRIPTION
The Chat context keeps track of which files the LLM knows about. This is to prevent edits to a file that has not been read yet, or that has changed since it has last been read/edited.

This PR fixes an issue where a file is sent as an attachment, and the edit is later rejected because the file has not been "read"

| Before | After |
|--------|-------|
| ![Screenshot 2025-08-28 at 4 56 14 PM](https://github.com/user-attachments/assets/49bcace6-6706-47df-824b-0e0ef7690a8d) | ![Screenshot 2025-08-28 at 4 54 03 PM](https://github.com/user-attachments/assets/5ca1ebdc-3c4e-4b0b-aadf-e71147c02d96) |