### PR TITLE
fix initial window positioning when Xcode is not launched, and add a button to launch Xcode

### DIFF
--- a/app/modules/App/Sources/Windows/SidePanel.swift
+++ b/app/modules/App/Sources/Windows/SidePanel.swift
@@ -47,13 +47,11 @@ final class SidePanel: XcodeWindow {
     let screen = NSScreen.screens.first?.frame
     let defaultFrame = defaultChatPositionIsInverted
       ? CGRect(x: 0, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
-      : CGRect(x: screen?.size.width ?? 0 - defaultWidth, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
+      : CGRect(x: (screen?.size.width ?? 0) - defaultWidth, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
 
     let frame = idealFrame ?? defaultFrame
-    if trackedWindow != nil {
-      setFrame(frame, display: isVisible)
-      makeKeyAndOrderFront(nil)
-    }
+    setFrame(frame, display: isVisible)
+    makeKeyAndOrderFront(nil)
     lastWindowFrame = frame
 
     backgroundColor = .clear

--- a/app/modules/App/Sources/Windows/SidePanel.swift
+++ b/app/modules/App/Sources/Windows/SidePanel.swift
@@ -47,7 +47,11 @@ final class SidePanel: XcodeWindow {
     let screen = NSScreen.screens.first?.frame
     let defaultFrame = defaultChatPositionIsInverted
       ? CGRect(x: 0, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
-      : CGRect(x: (screen?.size.width ?? defaultWidth) - defaultWidth, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
+      : CGRect(
+        x: (screen?.size.width ?? defaultWidth) - defaultWidth,
+        y: 0,
+        width: defaultWidth,
+        height: screen?.size.height ?? 1000)
 
     let frame = idealFrame ?? defaultFrame
     setFrame(frame, display: isVisible)

--- a/app/modules/App/Sources/Windows/SidePanel.swift
+++ b/app/modules/App/Sources/Windows/SidePanel.swift
@@ -47,7 +47,7 @@ final class SidePanel: XcodeWindow {
     let screen = NSScreen.screens.first?.frame
     let defaultFrame = defaultChatPositionIsInverted
       ? CGRect(x: 0, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
-      : CGRect(x: (screen?.size.width ?? 0) - defaultWidth, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
+      : CGRect(x: (screen?.size.width ?? defaultWidth) - defaultWidth, y: 0, width: defaultWidth, height: screen?.size.height ?? 1000)
 
     let frame = idealFrame ?? defaultFrame
     setFrame(frame, display: isVisible)

--- a/app/modules/features/Chat/ChatFeature/Sources/EmptyChatView.swift
+++ b/app/modules/features/Chat/ChatFeature/Sources/EmptyChatView.swift
@@ -32,7 +32,7 @@ struct EmptyChatView: View {
           .padding(.bottom, 4)
         keyBoardShortCutCard(
           title: "Add to current chat",
-          description: "Continue exisiting conversation with added context",
+          description: "Continue existing conversation with added context",
           keys: keyboardShortcuts[withDefault: .addContextToCurrentChat].keys)
         keyBoardShortCutCard(
           title: "Add to new chat",

--- a/app/modules/features/Chat/ChatFeature/Sources/EmptyChatView.swift
+++ b/app/modules/features/Chat/ChatFeature/Sources/EmptyChatView.swift
@@ -2,8 +2,11 @@
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 import Dependencies
+import DLS
 import SettingsServiceInterface
+import ShellServiceInterface
 import SwiftUI
+import XcodeObserverServiceInterface
 
 // MARK: - EmptyChatView
 
@@ -11,33 +14,77 @@ struct EmptyChatView: View {
   init() {
     @Dependency(\.settingsService) var settingsService
     _keyboardShortcuts = .init(initialValue: settingsService.value(for: \.keyboardShortcuts))
+    @Dependency(\.xcodeObserver) var xcodeObserver
+    _hasXcodeOpen = .init(initialValue: xcodeObserver.state.focusedInstance != nil)
   }
 
   var body: some View {
     VStack {
-      Text("Keyboard Shortcuts")
-        .padding(4)
-      Text("Get started quickly with these helpful commands")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .padding(.bottom, 4)
-      keyBoardShortCutCard(
-        title: "Add to current chat",
-        description: "Continue exisiting conversation with added context",
-        keys: keyboardShortcuts[withDefault: .addContextToCurrentChat].keys)
-      keyBoardShortCutCard(
-        title: "Add to new chat",
-        description: "Create a new conversation with the selected context",
-        keys: keyboardShortcuts[withDefault: .addContextToNewChat].keys)
-      keyBoardShortCutCard(
-        title: "Dismiss",
-        description: "Dismiss cmd. It'll still be available in the menu bar and respond to shortcuts",
-        keys: keyboardShortcuts[withDefault: .dismissChat].keys)
-      keyBoardShortCutCard(title: "Cycle chat mode", description: "Switch between different chat mode", keys: ["⇧", "⇥"])
+      if !hasXcodeOpen {
+        openXcodeButton
+          .padding(.top, 10)
+      } else {
+        Text("Keyboard Shortcuts")
+          .padding(4)
+        Text("Get started quickly with these helpful commands")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding(.bottom, 4)
+        keyBoardShortCutCard(
+          title: "Add to current chat",
+          description: "Continue exisiting conversation with added context",
+          keys: keyboardShortcuts[withDefault: .addContextToCurrentChat].keys)
+        keyBoardShortCutCard(
+          title: "Add to new chat",
+          description: "Create a new conversation with the selected context",
+          keys: keyboardShortcuts[withDefault: .addContextToNewChat].keys)
+        keyBoardShortCutCard(
+          title: "Dismiss",
+          description: "Dismiss cmd. It'll still be available in the menu bar and respond to shortcuts",
+          keys: keyboardShortcuts[withDefault: .dismissChat].keys)
+        keyBoardShortCutCard(title: "Cycle chat mode", description: "Switch between different chat mode", keys: ["⇧", "⇥"])
+      }
     }
     .onReceive(settingsService.liveValue(for: \.keyboardShortcuts), perform: { keyboardShortcuts in
       self.keyboardShortcuts = keyboardShortcuts
     })
+    .onReceive(xcodeObserver.statePublisher, perform: { newXcodeState in
+      hasXcodeOpen = newXcodeState.focusedInstance != nil
+    })
+  }
+
+  @ViewBuilder
+  var openXcodeButton: some View {
+    VStack {
+      HoveredButton(
+        action: {
+          Task {
+            do {
+              guard
+                let xcodePath = try await shellService.run("xcode-select --print-path").stdout?
+                  .trimmingCharacters(in: .whitespacesAndNewlines).split(separator: ".app").first
+              else {
+                xcodeOpenError = "Could not find Xcode. Please ensure Xcode is installed."
+                return
+              }
+              try await shellService.run("open \(xcodePath).app")
+            } catch {
+              xcodeOpenError = "Could not open Xcode: \(error.localizedDescription)"
+            }
+          }
+        },
+        onHoverColor: colorScheme.tertiarySystemBackground,
+        backgroundColor: colorScheme.secondarySystemBackground,
+        padding: 8,
+        content: {
+          Text("Open Xcode")
+        })
+      if let xcodeOpenError {
+        Text(xcodeOpenError)
+          .foregroundColor(colorScheme.redError)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .center)
   }
 
   @ViewBuilder
@@ -76,11 +123,15 @@ struct EmptyChatView: View {
       borderWidth: 0.5)
   }
 
+  @State private var hasXcodeOpen: Bool
+  @State private var xcodeOpenError: String?
+
   @State private var keyboardShortcuts: SettingsServiceInterface.Settings.KeyboardShortcuts
   @Environment(\.colorScheme) private var colorScheme
 
   @Dependency(\.settingsService) private var settingsService
-
+  @Dependency(\.xcodeObserver) private var xcodeObserver
+  @Dependency(\.shellService) private var shellService
 }
 
 extension SettingsServiceInterface.Settings.KeyboardShortcut {


### PR DESCRIPTION
When Xcode is not open but cmd is, cmd would size itself to a really small window.

- Fix this
- Add a button to launch Xcode when the chat view is empty

<img width="412" height="912" alt="Screenshot 2025-09-03 at 10 21 27 PM" src="https://github.com/user-attachments/assets/15298f78-5404-4536-96c6-0514341d7d87" />
