### PR TITLE
Improve handling of corrupted tool input

### DIFF
--- a/app/modules/foundations/AppFoundation/Sources/DoubleOptional.swift
+++ b/app/modules/foundations/AppFoundation/Sources/DoubleOptional.swift
@@ -1,0 +1,30 @@
+/// Custom operator for unwrapping double optionals (Optional<Optional<T>>)
+/// This operator provides a convenient way to handle nested optionals with a default value
+infix operator ???
+
+/// Unwraps a double optional value, returning the inner value if present, or the default value otherwise
+/// - Parameters:
+///   - value: A double optional value (Optional<Optional<T>>)
+///   - default: The default value to return if either optional layer is nil
+/// - Returns: The unwrapped value if both optional layers contain a value, otherwise the default
+/// - Example:
+///   ```swift
+///   let doubleOptional: Int?? = 42
+///   let result = doubleOptional ??? 0  // Returns 42
+///
+///   let nilOuter: Int?? = nil
+///   let result2 = nilOuter ??? 0  // Returns 0
+///
+///   let nilInner: Int?? = Optional<Int>.none
+///   let result3 = nilInner ??? 0  // Returns 0
+///   ```
+public func ??? <T>(value: T??, default: T) -> T {
+  switch value {
+  case .some(let wrapped):
+    // If outer optional has value, unwrap inner optional with ?? operator
+    wrapped ?? `default`
+  case .none:
+    // If outer optional is nil, return default
+    `default`
+  }
+}

--- a/app/modules/foundations/ToolFoundation/Sources/Tool.swift
+++ b/app/modules/foundations/ToolFoundation/Sources/Tool.swift
@@ -317,6 +317,10 @@ extension UpdatableToolUse {
   public func waitForApproval() {
     updateStatus.yield(.pendingApproval)
   }
+
+  public func complete(with error: Error) {
+    updateStatus.complete(with: .failure(error))
+  }
 }
 
 // MARK: - ExternalTool

--- a/app/modules/plugins/tools/EditFilesTool/Sources/EditFilesTool.swift
+++ b/app/modules/plugins/tools/EditFilesTool/Sources/EditFilesTool.swift
@@ -129,8 +129,7 @@ public final class EditFilesTool: Tool {
 
       public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: String.self)
-        // Decode all the values possible, and drop those that are still missing required properties to be decoded.
-        files = try container.resilientlyDecode([FileChange].self, forKey: "files")
+        files = try container.decode([FileChange].self, forKey: "files")
       }
 
       public struct FileChange: Codable, Sendable {

--- a/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
+++ b/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
@@ -264,9 +264,6 @@ actor RequestStreamingHelper: Sendable {
           isInputComplete: false,
           context: context.toolExecutionContext)
 
-        if !toolUse.isReadonly {
-          await context.prepareForWriteToolUse()
-        }
         streamingToolUse = toolUse
         content.append(toolUse: toolUse)
         result.update(with: AssistantMessage(content: content))
@@ -292,6 +289,9 @@ actor RequestStreamingHelper: Sendable {
           toolUse.waitForApproval()
           try await context.requestApproval(for: toolUse)
         }
+      }
+      if !toolUse.isReadonly {
+        await context.prepareForWriteToolUse()
       }
       toolUse.startExecuting()
     } catch is CancellationError {
@@ -387,7 +387,9 @@ actor RequestStreamingHelper: Sendable {
           isInputComplete: true,
           context: context.toolExecutionContext)
 
-        if !toolUse.isReadonly {
+        if !toolUse.isReadonly, tool.isExternalTool {
+          // We create a checkpoint now for external tools, as we do not control when the execution starts.
+          // For internal tool, this will be done in `startExecution` after validating permissions.
           await context.prepareForWriteToolUse()
         }
         content.append(toolUse: toolUse)

--- a/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
+++ b/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
@@ -322,24 +322,46 @@ actor RequestStreamingHelper: Sendable {
         assertionFailure("Received a tool use request for a different tool use ID while already streaming a tool use.")
       }
       do {
-        try toolUse.receive(inputUpdate: toolUseRequest.input.asJSONData(), isLast: true)
+        // Complete the tool use input with the final data received from the server.
+        // This marks the end of streaming input for this tool use.
+        if toolUse.toolName == "edit_or_create_files" {
+          let mock = """
+            {"files":[{"changes":{"searchh":"        // here?","replace":"        // Update the existing streaming tool use with newly received input data.\n        // This continues the streaming process for a tool that's already been initialized."},"path":"./modules/services/LLMService/Sources/RequestStreamingHelper.swift"}]}
+            """
+          try toolUse.receive(inputUpdate: mock.utf8Data, isLast: true)
+        } else {
+          try toolUse.receive(inputUpdate: toolUseRequest.input.asJSONData(), isLast: true)
+        }
+        endStreamedToolUse()
+        await startExecution(of: toolUse, context: context)
       } catch {
-        defaultLogger.error("Could not parse input for tool \(toolUseRequest.toolName)@\(toolUseRequest.toolUseId): \(error)")
-        // If the above fails, this is because the input could not be parsed by the tool.
-        var content = result.content
-        assert(
-          content.last?.asToolUseRequest?.toolUse.toolUseId == toolUse.toolUseId,
-          "The last content should be the tool use request we are ending.")
-        content.removeLast()
-        content.append(toolUse: FailedToolUse(
-          toolUseId: toolUse.toolUseId,
-          toolName: toolUse.toolName,
-          errorDescription: Self.failedToParseToolInputError(toolName: toolUse.toolName, error: error).localizedDescription,
-          context: context.toolExecutionContext))
-        result.update(with: AssistantMessage(content: content))
+        defaultLogger.error("Could not parse input for tool \(toolUseRequest.toolName)@\(toolUseRequest.toolUseId)", error)
+        if let updatableToolUse = toolUse as? (any UpdatableToolUse) {
+          print(type(of: error))
+          if let decodingError = error as? DecodingError {
+            updatableToolUse.complete(with: AppError(message: decodingError.llmErrorDescription))
+          } else {
+            updatableToolUse.complete(with: error)
+          }
+        } else {
+          // We are not able to update the tool use with the failure. So we cancel it and create a new tool use to represent the error.
+          toolUse.cancel()
+
+          // If the above fails, this is because the input could not be parsed by the tool.
+          var content = result.content
+          assert(
+            content.last?.asToolUseRequest?.toolUse.toolUseId == toolUse.toolUseId,
+            "The last content should be the tool use request we are ending.")
+          content.removeLast()
+          content.append(toolUse: FailedToolUse(
+            toolUseId: toolUse.toolUseId,
+            toolName: toolUse.toolName,
+            errorDescription: Self.failedToParseToolInputError(toolName: toolUse.toolName, error: error).localizedDescription,
+            context: context.toolExecutionContext))
+          result.update(with: AssistantMessage(content: content))
+        }
+        endStreamedToolUse()
       }
-      endStreamedToolUse()
-      await startExecution(of: toolUse, context: context)
       return
     }
 

--- a/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
+++ b/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
@@ -324,14 +324,7 @@ actor RequestStreamingHelper: Sendable {
       do {
         // Complete the tool use input with the final data received from the server.
         // This marks the end of streaming input for this tool use.
-        if toolUse.toolName == "edit_or_create_files" {
-          let mock = """
-            {"files":[{"changes":{"searchh":"        // here?","replace":"        // Update the existing streaming tool use with newly received input data.\n        // This continues the streaming process for a tool that's already been initialized."},"path":"./modules/services/LLMService/Sources/RequestStreamingHelper.swift"}]}
-            """
-          try toolUse.receive(inputUpdate: mock.utf8Data, isLast: true)
-        } else {
-          try toolUse.receive(inputUpdate: toolUseRequest.input.asJSONData(), isLast: true)
-        }
+        try toolUse.receive(inputUpdate: toolUseRequest.input.asJSONData(), isLast: true)
         endStreamedToolUse()
         await startExecution(of: toolUse, context: context)
       } catch {
@@ -399,7 +392,7 @@ actor RequestStreamingHelper: Sendable {
       } catch {
         defaultLogger
           .error(
-            "Could not parse input for tool \(request.toolName)@\(request.toolUseId):\n\(error)\nInput:\(String(data: (try! JSONEncoder().encode(request.input)), encoding: .utf8) ?? "unreadable")")
+            "Could not parse input for tool \(request.toolName)@\(request.toolUseId):\n\(error)\nInput:\((try? JSONEncoder().encode(request.input)).map { String(data: $0, encoding: .utf8) } ??? "unreadable")")
         var err = error
         if let decodingError = error as? DecodingError {
           err = AppError(message: decodingError.llmErrorDescription)

--- a/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
+++ b/app/modules/services/LLMService/Sources/RequestStreamingHelper.swift
@@ -336,13 +336,13 @@ actor RequestStreamingHelper: Sendable {
         await startExecution(of: toolUse, context: context)
       } catch {
         defaultLogger.error("Could not parse input for tool \(toolUseRequest.toolName)@\(toolUseRequest.toolUseId)", error)
+        var err = error
+        if let decodingError = error as? DecodingError {
+          err = AppError(message: decodingError.llmErrorDescription)
+        }
+
         if let updatableToolUse = toolUse as? (any UpdatableToolUse) {
-          print(type(of: error))
-          if let decodingError = error as? DecodingError {
-            updatableToolUse.complete(with: AppError(message: decodingError.llmErrorDescription))
-          } else {
-            updatableToolUse.complete(with: error)
-          }
+          updatableToolUse.complete(with: err)
         } else {
           // We are not able to update the tool use with the failure. So we cancel it and create a new tool use to represent the error.
           toolUse.cancel()
@@ -356,7 +356,7 @@ actor RequestStreamingHelper: Sendable {
           content.append(toolUse: FailedToolUse(
             toolUseId: toolUse.toolUseId,
             toolName: toolUse.toolName,
-            errorDescription: Self.failedToParseToolInputError(toolName: toolUse.toolName, error: error).localizedDescription,
+            errorDescription: Self.failedToParseToolInputError(toolName: toolUse.toolName, error: err).localizedDescription,
             context: context.toolExecutionContext))
           result.update(with: AssistantMessage(content: content))
         }
@@ -400,11 +400,15 @@ actor RequestStreamingHelper: Sendable {
         defaultLogger
           .error(
             "Could not parse input for tool \(request.toolName)@\(request.toolUseId):\n\(error)\nInput:\(String(data: (try! JSONEncoder().encode(request.input)), encoding: .utf8) ?? "unreadable")")
+        var err = error
+        if let decodingError = error as? DecodingError {
+          err = AppError(message: decodingError.llmErrorDescription)
+        }
         // If the above fails, this is because the input could not be parsed by the tool.
         content.append(toolUse: FailedToolUse(
           toolUseId: request.toolUseId,
           toolName: request.toolName,
-          errorDescription: Self.failedToParseToolInputError(toolName: request.toolName, error: error).localizedDescription,
+          errorDescription: Self.failedToParseToolInputError(toolName: request.toolName, error: err).localizedDescription,
           context: context.toolExecutionContext))
       }
     } else {

--- a/app/modules/services/LLMService/Sources/helpers.swift
+++ b/app/modules/services/LLMService/Sources/helpers.swift
@@ -83,3 +83,45 @@ extension Schema.ToolResultMessage.Result {
     .failure(["error": .string(errorDescription)])
   }
 }
+
+extension DecodingError {
+  /// A detailed description that is meant to send enough debugging information back to the LLM
+  var llmErrorDescription: String {
+    switch self {
+    case .valueNotFound(let type, let context):
+      return context.llmErrorDescription
+    case .dataCorrupted(let context):
+      return context.llmErrorDescription
+    case .typeMismatch(let type, let context):
+      return context.llmErrorDescription
+    case .keyNotFound(let key, let context):
+      return context.llmErrorDescription
+    @unknown default:
+      return localizedDescription
+    }
+  }
+}
+
+extension DecodingError.Context {
+  fileprivate var llmErrorDescription: String {
+    var description = "Error at coding path: \(codingPath.description): " + debugDescription
+    if let underlyingError, let debugDescription = (underlyingError as NSError).userInfo[NSDebugDescriptionErrorKey] as? String {
+      description += " Underlying error: \(debugDescription)"
+    }
+    return description
+  }
+}
+
+extension [any CodingKey] {
+  fileprivate var description: String {
+    var description = ""
+    for key in self {
+      if let i = key.intValue {
+        description += "[\(i)]"
+      } else {
+        description += "\(description.isEmpty ? "" : ".")\(key.stringValue)"
+      }
+    }
+    return description
+  }
+}

--- a/app/modules/services/LLMService/Sources/helpers.swift
+++ b/app/modules/services/LLMService/Sources/helpers.swift
@@ -103,8 +103,8 @@ extension DecodingError {
 }
 
 extension DecodingError.Context {
-  fileprivate var llmErrorDescription: String {
-    var description = "Error at coding path: \(codingPath.description): " + debugDescription
+  var llmErrorDescription: String {
+    var description = "Error at coding path: '\(codingPath.description)': " + debugDescription
     if let underlyingError, let debugDescription = (underlyingError as NSError).userInfo[NSDebugDescriptionErrorKey] as? String {
       description += " Underlying error: \(debugDescription)"
     }
@@ -113,13 +113,13 @@ extension DecodingError.Context {
 }
 
 extension [any CodingKey] {
-  fileprivate var description: String {
+  var description: String {
     var description = ""
     for key in self {
       if let i = key.intValue {
         description += "[\(i)]"
       } else {
-        description += "\(description.isEmpty ? "" : ".")\(key.stringValue)"
+        description += ".\(key.stringValue)"
       }
     }
     return description

--- a/app/modules/services/LLMService/Tests/APIs/SendOneMessageTests.swift
+++ b/app/modules/services/LLMService/Tests/APIs/SendOneMessageTests.swift
@@ -280,7 +280,7 @@ final class SendOneMessageTests {
         #expect(toolCall.toolUse.toolUseId == "123")
         #expect(
           (toolCall.toolUse as? FailedToolUse)?.errorDescription ==
-            "Could not parse the input for tool read_file: The data couldn’t be read because it is missing.")
+            "Could not parse the input for tool read_file: Error at coding path: \'\': No value associated with key CodingKeys(stringValue: \"file\", intValue: nil) (\"file\").")
         toolCallReceived.fulfill()
       }
       messagesReceived.fulfill()

--- a/app/modules/services/LLMService/Tests/BadToolInputTests.swift
+++ b/app/modules/services/LLMService/Tests/BadToolInputTests.swift
@@ -1,0 +1,140 @@
+// Copyright cmd app, Inc. Licensed under the Apache License, Version 2.0.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+import Foundation
+import Testing
+@testable import LLMService
+
+// MARK: - BadToolInputTests
+
+@Suite("Bad Tool Input Handling Tests")
+struct BadToolInputTests {
+
+  @Test("DecodingError provides detailed LLM error description")
+  func testDecodingErrorLLMDescription() throws {
+    // Test keyNotFound error
+    let keyNotFoundContext = DecodingError.Context(
+      codingPath: [MockCodingKey(stringValue: "files"), MockCodingKey(intValue: 0), MockCodingKey(stringValue: "path")],
+      debugDescription: "No value associated with key 'path'")
+    let keyNotFoundError = DecodingError.keyNotFound(MockCodingKey(stringValue: "path"), keyNotFoundContext)
+
+    let errorDescription = keyNotFoundError.llmErrorDescription
+    #expect(errorDescription.contains("files[0].path"))
+    #expect(errorDescription.contains("No value associated with key 'path'"))
+
+    // Test typeMismatch error
+    let typeMismatchContext = DecodingError.Context(
+      codingPath: [MockCodingKey(stringValue: "files"), MockCodingKey(intValue: 0), MockCodingKey(stringValue: "changes")],
+      debugDescription: "Expected to decode Array but found a string")
+    let typeMismatchError = DecodingError.typeMismatch([String].self, typeMismatchContext)
+
+    let typeMismatchDescription = typeMismatchError.llmErrorDescription
+    #expect(typeMismatchDescription.contains("files[0].changes"))
+    #expect(typeMismatchDescription.contains("Expected to decode Array but found a string"))
+  }
+
+  @Test("DecodingError context coding path description is formatted correctly")
+  func testCodingPathDescription() throws {
+    let codingPath: [any CodingKey] = [
+      MockCodingKey(stringValue: "root"),
+      MockCodingKey(intValue: 2),
+      MockCodingKey(stringValue: "nested"),
+      MockCodingKey(stringValue: "value"),
+    ]
+
+    let description = codingPath.description
+    #expect(description == ".root[2].nested.value")
+  }
+
+  @Test("Empty coding path returns empty description")
+  func testEmptyCodingPath() throws {
+    let emptyCodingPath: [any CodingKey] = []
+    let description = emptyCodingPath.description
+    #expect(description == "")
+  }
+
+  @Test("Array-only coding path is formatted correctly")
+  func testArrayOnlyCodingPath() throws {
+    let arrayOnlyCodingPath: [any CodingKey] = [
+      MockCodingKey(intValue: 0),
+      MockCodingKey(intValue: 1),
+      MockCodingKey(intValue: 2),
+    ]
+
+    let description = arrayOnlyCodingPath.description
+    #expect(description == "[0][1][2]")
+  }
+
+  @Test("Mixed coding path with root array is formatted correctly")
+  func testMixedCodingPathWithRootArray() throws {
+    let mixedCodingPath: [any CodingKey] = [
+      MockCodingKey(intValue: 0),
+      MockCodingKey(stringValue: "property"),
+      MockCodingKey(intValue: 5),
+      MockCodingKey(stringValue: "value"),
+    ]
+
+    let description = mixedCodingPath.description
+    #expect(description == "[0].property[5].value")
+  }
+
+  @Test("ValueNotFound error provides context description")
+  func testValueNotFoundError() throws {
+    let context = DecodingError.Context(
+      codingPath: [MockCodingKey(stringValue: "required_field")],
+      debugDescription: "Expected String value but found null")
+    let error = DecodingError.valueNotFound(String.self, context)
+
+    let description = error.llmErrorDescription
+    #expect(description.contains("required_field"))
+    #expect(description.contains("Expected String value but found null"))
+  }
+
+  @Test("DataCorrupted error provides context description")
+  func testDataCorruptedError() throws {
+    let context = DecodingError.Context(
+      codingPath: [MockCodingKey(stringValue: "malformed_json")],
+      debugDescription: "The given data was not valid JSON")
+    let error = DecodingError.dataCorrupted(context)
+
+    let description = error.llmErrorDescription
+    #expect(description.contains("malformed_json"))
+    #expect(description.contains("The given data was not valid JSON"))
+  }
+
+  @Test("DecodingError with underlying error provides comprehensive description")
+  func testDecodingErrorWithUnderlyingError() throws {
+    let underlyingError = NSError(
+      domain: "TestDomain",
+      code: 123,
+      userInfo: [NSDebugDescriptionErrorKey: "Underlying error details"])
+
+    let context = DecodingError.Context(
+      codingPath: [MockCodingKey(stringValue: "test")],
+      debugDescription: "Main error description",
+      underlyingError: underlyingError)
+
+    let error = DecodingError.dataCorrupted(context)
+    let description = error.llmErrorDescription
+    #expect(description.contains("Main error description"))
+    #expect(description.contains("Underlying error details"))
+    #expect(description.contains("test"))
+  }
+}
+
+// MARK: - MockCodingKey
+
+private struct MockCodingKey: CodingKey {
+  let stringValue: String
+  let intValue: Int?
+
+  init(stringValue: String) {
+    self.stringValue = stringValue
+    intValue = nil
+  }
+
+  init(intValue: Int) {
+    stringValue = "\(intValue)"
+    self.intValue = intValue
+  }
+}


### PR DESCRIPTION
Improve handling of corrupted tool input. This can happen when the LLM sends a JSON payload that doesn't respect the provided schema, or is not even valid JSON.

- Creates a clear error message about the decoding failure, instead of Swift default debug description, to help the LLM autocorrect
- Ensure that the agent loop continues after the failure, and that the correct failure message is sent back
- Don't create a check point too early (ie not when we start receiving the tool input) but only when the tool will start executing (after input and permission validation) or only after input validation for external tools.