### PR TITLE
Fixes (Xcode 26, LLM providers API key serialization)

### DIFF
--- a/app/modules/Package.swift
+++ b/app/modules/Package.swift
@@ -421,6 +421,7 @@ targets.append(contentsOf: Target.module(
     "AccessibilityFoundation",
     "AppEventServiceInterface",
     "ChatAppEvents",
+    "ChatCompletionServiceInterface",
     "ChatFeatureInterface",
     "ChatFoundation",
     "ChatServiceInterface",

--- a/app/modules/coreui/DLS/Sources/CoreUI/FileIcon.swift
+++ b/app/modules/coreui/DLS/Sources/CoreUI/FileIcon.swift
@@ -151,5 +151,3 @@ private let resourceBundle = Bundle(for: ResourceBundle.self)
     .padding()
   }
 }
-
-extension NSImage: @retroactive @unchecked Sendable { }

--- a/app/modules/features/Chat/ChatFeature/Module.swift
+++ b/app/modules/features/Chat/ChatFeature/Module.swift
@@ -40,6 +40,7 @@ Target.module(
     "AccessibilityFoundation",
     "AppEventServiceInterface",
     "ChatAppEvents",
+    "ChatCompletionServiceInterface",
     "ChatFeatureInterface",
     "ChatFoundation",
     "ChatServiceInterface",

--- a/app/modules/features/Chat/ChatFeature/Sources/ChatCompletion/ChatViewModel+ChatCompletionServiceDelegate.swift
+++ b/app/modules/features/Chat/ChatFeature/Sources/ChatCompletion/ChatViewModel+ChatCompletionServiceDelegate.swift
@@ -43,8 +43,11 @@ extension ChatViewModel: ChatCompletionServiceDelegate {
         }
       }
 
-      continuation.onTermination = { _ in
-        cancellable.cancel()
+      continuation.onTermination = { @Sendable [weak cancellable] _ in
+        Task { @MainActor in
+          thread.cancelCurrentMessage()
+        }
+        cancellable?.cancel()
       }
     }
   }

--- a/app/modules/features/Chat/ChatFeature/Sources/ChatCompletion/ChatViewModel+ChatCompletionServiceDelegate.swift
+++ b/app/modules/features/Chat/ChatFeature/Sources/ChatCompletion/ChatViewModel+ChatCompletionServiceDelegate.swift
@@ -43,11 +43,11 @@ extension ChatViewModel: ChatCompletionServiceDelegate {
         }
       }
 
-      continuation.onTermination = { @Sendable [weak cancellable] _ in
+      continuation.onTermination = { @Sendable _ in
         Task { @MainActor in
           thread.cancelCurrentMessage()
         }
-        cancellable?.cancel()
+        cancellable.cancel()
       }
     }
   }

--- a/app/modules/features/Chat/ChatFeature/Sources/EmptyChatView.swift
+++ b/app/modules/features/Chat/ChatFeature/Sources/EmptyChatView.swift
@@ -48,7 +48,7 @@ struct EmptyChatView: View {
     .onReceive(settingsService.liveValue(for: \.keyboardShortcuts), perform: { keyboardShortcuts in
       self.keyboardShortcuts = keyboardShortcuts
     })
-    .onReceive(xcodeObserver.statePublisher, perform: { newXcodeState in
+    .onReceive(xcodeObserver.statePublisher.receive(on: DispatchQueue.main), perform: { newXcodeState in
       hasXcodeOpen = newXcodeState.focusedInstance != nil
     })
   }

--- a/app/modules/features/Chat/ChatFeature/Tests/ChatCompletion/ChatViewModel+ChatCompletionServiceDelegateTests.swift
+++ b/app/modules/features/Chat/ChatFeature/Tests/ChatCompletion/ChatViewModel+ChatCompletionServiceDelegateTests.swift
@@ -1,0 +1,98 @@
+// Copyright cmd app, Inc. Licensed under the Apache License, Version 2.0.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+import ChatCompletionServiceInterface
+import Combine
+import ConcurrencyFoundation
+import Dependencies
+import Foundation
+import LLMServiceInterface
+import SwiftTesting
+import Testing
+@testable import ChatFeature
+
+extension ChatViewModelTests {
+
+  @MainActor
+  @Test("client cancellation behavior is properly implemented")
+  func test_clientCancellation_behaviorImplemented() async throws {
+    // given
+    let mockLLMService = MockLLMService()
+
+    let testThreadId = UUID()
+
+    let (threadViewModel, chatViewModel) = withDependencies {
+      $0.withAllModelAvailable()
+      $0.llmService = mockLLMService
+    } operation: {
+      let thread = ChatThreadViewModel(id: testThreadId)
+      let sut = ChatViewModel()
+      sut.tab = thread
+      return (thread, sut)
+    }
+
+    let isDoneStreaming = expectation(description: "is done streaming")
+    let hasReceivedOneStreamedChunk = expectation(description: "has received one streamed chunk")
+    let threadChangedFromStreamingToNotStreaming = expectation(description: "thread changed from streaming to not streaming")
+
+    mockLLMService.onSendMessage = { _, _, _, _, _, handleUpdateStream in
+      let updateStream = MutableCurrentValueStream<[CurrentValueStream<AssistantMessage>]>([])
+      handleUpdateStream(updateStream)
+
+      let message = MutableCurrentValueStream<AssistantMessage>(.init(content: []))
+      updateStream.update(with: [message])
+
+      let firstTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "hello"))
+      message.update(with: AssistantMessage(content: [.text(firstTextContent)]))
+      firstTextContent.finish()
+
+      try await fulfillment(of: isDoneStreaming)
+
+      let secondTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "world"))
+      message.update(with: AssistantMessage(content: [.text(firstTextContent), .text(secondTextContent)]))
+      secondTextContent.finish()
+      message.finish()
+      updateStream.finish()
+      return SendMessageResponse(newMessages: [], usageInfo: nil)
+    }
+
+    // when
+    let chatCompletionInput = ChatCompletionInput(
+      threadId: testThreadId.uuidString,
+      newUserMessages: ["Test message for client cancellation"],
+      modelName: "gpt-5")
+
+    // Handle the chat completion and get the stream
+    let receivedEvents = Atomic<[[ChatCompletionServiceInterface.ChatEvent]]>([])
+    let task = Task {
+      let eventStream = try await chatViewModel.handle(chatCompletion: chatCompletionInput)
+      for await event in eventStream {
+        let events = receivedEvents.mutate {
+          $0.append(event)
+          return $0
+        }
+        if events.flatMap(\.self).count == 1 {
+          hasReceivedOneStreamedChunk.fulfill()
+        }
+      }
+    }
+
+    let wasStreaming = Atomic(threadViewModel.isStreamingResponse)
+    let cancellable = threadViewModel.observeChanges(to: \.isStreamingResponse) { @Sendable value in
+      if wasStreaming.value, !value {
+        threadChangedFromStreamingToNotStreaming.fulfill()
+      }
+      wasStreaming.set(to: value)
+    }
+
+    try await fulfillment(of: hasReceivedOneStreamedChunk)
+    #expect(threadViewModel.isStreamingResponse)
+    task.cancel()
+    try await fulfillment(of: threadChangedFromStreamingToNotStreaming)
+    #expect(receivedEvents.value.flatMap(\.self).map(\.content) == ["hello"])
+
+    // Clean up
+    _ = await task.result
+    _ = cancellable
+  }
+}

--- a/app/modules/features/Chat/ChatFeature/Tests/ChatThreadViewModelTests.swift
+++ b/app/modules/features/Chat/ChatFeature/Tests/ChatThreadViewModelTests.swift
@@ -2,10 +2,13 @@
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 import AppEventServiceInterface
+import ChatFeatureInterface
+import Combine
 import ConcurrencyFoundation
 import Dependencies
 import ExtensionEventsInterface
 import Foundation
+import LLMServiceInterface
 import LocalServerServiceInterface
 import SharedValuesFoundation
 import SwiftTesting
@@ -182,6 +185,70 @@ struct ChatThreadViewModelTests {
     // Assert
     #expect(handled == false)
     _ = sut // Keep reference
+  }
+
+  @MainActor
+  @Test("receiving messages updates state")
+  func test_receivingMessages_updatesState() async throws {
+    // given
+    let mockLLMService = MockLLMService()
+
+    let testThreadId = UUID()
+
+    let sut = withDependencies {
+      $0.withAllModelAvailable()
+      $0.llmService = mockLLMService
+    } operation: {
+      ChatThreadViewModel(id: testThreadId)
+    }
+
+    let isDoneStreaming = expectation(description: "is done streaming")
+
+    mockLLMService.onSendMessage = { _, _, _, _, _, handleUpdateStream in
+      let updateStream = MutableCurrentValueStream<[CurrentValueStream<AssistantMessage>]>([])
+      handleUpdateStream(updateStream)
+
+      let message = MutableCurrentValueStream<AssistantMessage>(.init(content: []))
+      updateStream.update(with: [message])
+
+      let firstTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "hello"))
+      message.update(with: AssistantMessage(content: [.text(firstTextContent)]))
+      firstTextContent.finish()
+
+      let secondTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "world"))
+      message.update(with: AssistantMessage(content: [.text(firstTextContent), .text(secondTextContent)]))
+      secondTextContent.finish()
+
+      message.finish()
+      updateStream.finish()
+
+      return SendMessageResponse(newMessages: [], usageInfo: nil)
+    }
+
+    var cancellables = Set<AnyCancellable>()
+
+    let eventsHistory = Atomic<[[ChatEvent]]>([])
+    sut.observeChanges(to: \.events) { value in
+      eventsHistory.mutate { $0.append(value) }
+    }.store(in: &cancellables)
+
+    let wasStreaming = Atomic(false)
+    sut.observeChanges(to: \.isStreamingResponse) { value in
+      if wasStreaming.set(to: value), !value {
+        isDoneStreaming.fulfill()
+      }
+    }.store(in: &cancellables)
+
+    // when
+    sut.input.textInput = .init(NSAttributedString(string: "hello"))
+    await sut.sendMessage()
+
+    // then
+    try await fulfillment(of: isDoneStreaming)
+    #expect(eventsHistory.value.map { $0.map { $0.message?.content.asText?.text } } == [["hello"], ["hello", "world"]])
+
+    // Clean up
+    _ = cancellables
   }
 
 }

--- a/app/modules/features/Chat/ChatFeature/Tests/ChatThreadViewModelTests.swift
+++ b/app/modules/features/Chat/ChatFeature/Tests/ChatThreadViewModelTests.swift
@@ -152,6 +152,7 @@ struct ChatThreadViewModelTests {
 
     // Assert
     #expect(handled == false)
+    #expect(sut.name == nil) // Name should remain unchanged
   }
 
   @MainActor

--- a/app/modules/features/Chat/ChatFeature/Tests/ChatViewModelTests.swift
+++ b/app/modules/features/Chat/ChatFeature/Tests/ChatViewModelTests.swift
@@ -5,6 +5,7 @@ import AccessibilityFoundation
 import AppEventServiceInterface
 import AppKit
 import ChatAppEvents
+import ChatCompletionServiceInterface
 import ChatFeatureInterface
 import ChatFoundation
 import ChatServiceInterface
@@ -981,6 +982,109 @@ struct ChatViewModelTests {
       }
     }
     #expect(summaryMessages.count == 0)
+  }
+
+  @MainActor
+  @Test("client cancellation behavior is properly implemented")
+  func test_clientCancellation_behaviorImplemented() async throws {
+    // given
+    let mockChatHistoryService = MockChatHistoryService()
+    let mockLLMService = MockLLMService()
+
+    let testThreadId = UUID()
+
+    let (threadViewModel, chatViewModel) = withDependencies {
+      $0.withAllModelAvailable()
+      $0.chatHistoryService = mockChatHistoryService
+      $0.llmService = mockLLMService
+    } operation: {
+      let thread = ChatThreadViewModel(id: testThreadId)
+      let sut = ChatViewModel()
+      sut.tab = thread
+      return (thread, sut)
+    }
+
+    let isDoneStreaming = expectation(description: "is done streaming")
+    let hasReceivedOneStreamedChunk = expectation(description: "has received one streamed chunk")
+    let threadChangedFromStreamingToNotStreaming = expectation(description: "thread changed from streaming to not streaming")
+
+    mockLLMService.onSendMessage = { _, _, _, _, _, handleUpdateStream in
+      let updateStream = MutableCurrentValueStream<[CurrentValueStream<AssistantMessage>]>([])
+      handleUpdateStream(updateStream)
+
+      let message = MutableCurrentValueStream<AssistantMessage>(.init(content: []))
+      updateStream.update(with: [message])
+
+      let firstTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "", deltas: []))
+      message.update(with: AssistantMessage(content: [.text(firstTextContent)]))
+      firstTextContent.update(with: .init(content: "hello", deltas: ["hello"]))
+      firstTextContent.finish()
+
+      try await fulfillment(of: isDoneStreaming)
+
+      let secondTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "", deltas: []))
+      message.update(with: AssistantMessage(content: [.text(firstTextContent), .text(secondTextContent)]))
+      firstTextContent.update(with: .init(content: "world", deltas: ["world"]))
+      secondTextContent.finish()
+      message.finish()
+      updateStream.finish()
+      return SendMessageResponse(newMessages: [], usageInfo: nil)
+    }
+
+    // when
+    let chatCompletionInput = ChatCompletionInput(
+      threadId: testThreadId.uuidString,
+      newUserMessages: ["Test message for client cancellation"],
+      modelName: "gpt-5")
+
+    // Handle the chat completion and get the stream
+    let receivedEvents = Atomic<[[ChatCompletionServiceInterface.ChatEvent]]>([])
+    let task = Task {
+      let eventStream = try await chatViewModel.handle(chatCompletion: chatCompletionInput)
+      for await event in eventStream {
+        receivedEvents.mutate { $0.append(event) }
+        if receivedEvents.value.count == 1 {
+          hasReceivedOneStreamedChunk.fulfill()
+        }
+      }
+    }
+
+    let wasStreaming = Atomic(threadViewModel.isStreamingResponse)
+    let cancellable = threadViewModel.observeChanges(to: \.isStreamingResponse) { @Sendable value in
+      if wasStreaming.value, !value {
+        threadChangedFromStreamingToNotStreaming.fulfill()
+      }
+      wasStreaming.set(to: value)
+    }
+
+    try await fulfillment(of: hasReceivedOneStreamedChunk)
+    #expect(threadViewModel.isStreamingResponse)
+    task.cancel()
+    try await fulfillment(of: threadChangedFromStreamingToNotStreaming)
+//
+//    // Verify that the thread started streaming
+//    let wasStreamingBeforeCancellation = threadViewModel.isStreamingResponse
+//
+//    // Cancel the stream consumption task (simulates client disconnect)
+//      task.cancel()
+//
+//    // Allow time for cancellation to propagate through the AsyncStream's onTermination
+//    try? await Task.sleep(nanoseconds: 50_000_000) // 0.05 seconds
+//
+//    // Verify that the thread's streaming state was properly cleared
+//    let isStreamingAfterCancellation = threadViewModel.isStreamingResponse
+//
+//    // Clean up
+    _ = await task.result
+    _ = cancellable
+//
+//    // then
+//    // This test validates the fix from commit 301ade5:
+//    // - When a client cancels their stream consumption, the AsyncStream's onTermination should trigger
+//    // - The onTermination callback calls thread.cancelCurrentMessage()
+//    // - This should clear the streaming state on the thread
+//    #expect(wasStreamingBeforeCancellation == true)
+//    #expect(isStreamingAfterCancellation == false)
   }
 
   @MainActor

--- a/app/modules/features/Chat/ChatFeature/Tests/ChatViewModelTests.swift
+++ b/app/modules/features/Chat/ChatFeature/Tests/ChatViewModelTests.swift
@@ -5,7 +5,6 @@ import AccessibilityFoundation
 import AppEventServiceInterface
 import AppKit
 import ChatAppEvents
-import ChatCompletionServiceInterface
 import ChatFeatureInterface
 import ChatFoundation
 import ChatServiceInterface
@@ -982,109 +981,6 @@ struct ChatViewModelTests {
       }
     }
     #expect(summaryMessages.count == 0)
-  }
-
-  @MainActor
-  @Test("client cancellation behavior is properly implemented")
-  func test_clientCancellation_behaviorImplemented() async throws {
-    // given
-    let mockChatHistoryService = MockChatHistoryService()
-    let mockLLMService = MockLLMService()
-
-    let testThreadId = UUID()
-
-    let (threadViewModel, chatViewModel) = withDependencies {
-      $0.withAllModelAvailable()
-      $0.chatHistoryService = mockChatHistoryService
-      $0.llmService = mockLLMService
-    } operation: {
-      let thread = ChatThreadViewModel(id: testThreadId)
-      let sut = ChatViewModel()
-      sut.tab = thread
-      return (thread, sut)
-    }
-
-    let isDoneStreaming = expectation(description: "is done streaming")
-    let hasReceivedOneStreamedChunk = expectation(description: "has received one streamed chunk")
-    let threadChangedFromStreamingToNotStreaming = expectation(description: "thread changed from streaming to not streaming")
-
-    mockLLMService.onSendMessage = { _, _, _, _, _, handleUpdateStream in
-      let updateStream = MutableCurrentValueStream<[CurrentValueStream<AssistantMessage>]>([])
-      handleUpdateStream(updateStream)
-
-      let message = MutableCurrentValueStream<AssistantMessage>(.init(content: []))
-      updateStream.update(with: [message])
-
-      let firstTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "", deltas: []))
-      message.update(with: AssistantMessage(content: [.text(firstTextContent)]))
-      firstTextContent.update(with: .init(content: "hello", deltas: ["hello"]))
-      firstTextContent.finish()
-
-      try await fulfillment(of: isDoneStreaming)
-
-      let secondTextContent = MutableCurrentValueStream<TextContentMessage>(.init(content: "", deltas: []))
-      message.update(with: AssistantMessage(content: [.text(firstTextContent), .text(secondTextContent)]))
-      firstTextContent.update(with: .init(content: "world", deltas: ["world"]))
-      secondTextContent.finish()
-      message.finish()
-      updateStream.finish()
-      return SendMessageResponse(newMessages: [], usageInfo: nil)
-    }
-
-    // when
-    let chatCompletionInput = ChatCompletionInput(
-      threadId: testThreadId.uuidString,
-      newUserMessages: ["Test message for client cancellation"],
-      modelName: "gpt-5")
-
-    // Handle the chat completion and get the stream
-    let receivedEvents = Atomic<[[ChatCompletionServiceInterface.ChatEvent]]>([])
-    let task = Task {
-      let eventStream = try await chatViewModel.handle(chatCompletion: chatCompletionInput)
-      for await event in eventStream {
-        receivedEvents.mutate { $0.append(event) }
-        if receivedEvents.value.count == 1 {
-          hasReceivedOneStreamedChunk.fulfill()
-        }
-      }
-    }
-
-    let wasStreaming = Atomic(threadViewModel.isStreamingResponse)
-    let cancellable = threadViewModel.observeChanges(to: \.isStreamingResponse) { @Sendable value in
-      if wasStreaming.value, !value {
-        threadChangedFromStreamingToNotStreaming.fulfill()
-      }
-      wasStreaming.set(to: value)
-    }
-
-    try await fulfillment(of: hasReceivedOneStreamedChunk)
-    #expect(threadViewModel.isStreamingResponse)
-    task.cancel()
-    try await fulfillment(of: threadChangedFromStreamingToNotStreaming)
-//
-//    // Verify that the thread started streaming
-//    let wasStreamingBeforeCancellation = threadViewModel.isStreamingResponse
-//
-//    // Cancel the stream consumption task (simulates client disconnect)
-//      task.cancel()
-//
-//    // Allow time for cancellation to propagate through the AsyncStream's onTermination
-//    try? await Task.sleep(nanoseconds: 50_000_000) // 0.05 seconds
-//
-//    // Verify that the thread's streaming state was properly cleared
-//    let isStreamingAfterCancellation = threadViewModel.isStreamingResponse
-//
-//    // Clean up
-    _ = await task.result
-    _ = cancellable
-//
-//    // then
-//    // This test validates the fix from commit 301ade5:
-//    // - When a client cancels their stream consumption, the AsyncStream's onTermination should trigger
-//    // - The onTermination callback calls thread.cancelCurrentMessage()
-//    // - This should clear the streaming state on the thread
-//    #expect(wasStreamingBeforeCancellation == true)
-//    #expect(isStreamingAfterCancellation == false)
   }
 
   @MainActor

--- a/app/modules/foundations/ConcurrencyFoundation/Sources/Observable+helpers.swift
+++ b/app/modules/foundations/ConcurrencyFoundation/Sources/Observable+helpers.swift
@@ -12,13 +12,18 @@ extension Observable where Self: Sendable {
     perform action: @Sendable @escaping (Value) -> Void)
     -> AnyCancellable
   {
-    let cancellable = AnyCancellable { }
+    let isCancelled = Atomic(false)
+    let cancellable = AnyCancellable {
+      isCancelled.set(to: true)
+    }
     withObservationTracking(
       {
         _ = self[keyPath: keyPath]
       },
-      token: { [weak cancellable] in
-        guard let cancellable else { return nil }
+      token: {
+        guard !isCancelled.value else {
+          return nil
+        }
         _ = cancellable
         return ""
       },
@@ -57,7 +62,10 @@ extension Observable where Self: Sendable {
   {
     let isFirstObservation = Atomic<Bool>(true)
 
-    let cancellable = AnyCancellable { }
+    let isCancelled = Atomic(false)
+    let cancellable = AnyCancellable {
+      isCancelled.set(to: true)
+    }
 
     withObservationTracking(
       {
@@ -67,9 +75,10 @@ extension Observable where Self: Sendable {
           action(value)
         }
       },
-      token: { [weak cancellable] in
-        guard let cancellable else { return nil }
-        _ = cancellable
+      token: {
+        guard !isCancelled.value else {
+          return nil
+        }
         return ""
       },
       willChange: nil,

--- a/app/modules/serviceInterfaces/LLMServiceInterface/Sources/Types.swift
+++ b/app/modules/serviceInterfaces/LLMServiceInterface/Sources/Types.swift
@@ -34,9 +34,9 @@ public enum AssistantMessageContent: Sendable { // TODO: rename to StreamedAssis
 public struct TextContentMessage: Sendable {
   // MARK: Lifecycle
 
-  public init(content: String, deltas: [String] = []) {
+  public init(content: String, deltas: [String]? = nil) {
     self.content = content
-    self.deltas = deltas
+    self.deltas = deltas ?? [content]
   }
 
   // MARK: Public

--- a/app/modules/services/LocalServerService/Sources/DefaultLocalServer.swift
+++ b/app/modules/services/LocalServerService/Sources/DefaultLocalServer.swift
@@ -370,6 +370,4 @@ extension BaseProviding where
   }
 }
 
-extension URLResponse: @unchecked @retroactive Sendable { }
-
 private let resourceBundle = Bundle.module

--- a/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
+++ b/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
@@ -90,26 +90,14 @@ final class DefaultSettingsService: SettingsService {
     if let data = userDefaults.data(forKey: Keys.appWideSettings) {
       do {
         var settings = try JSONDecoder().decode(Settings.self, from: data)
-        // Load API keys fromn the keychain.
-        if let anthropicAPIKey = settings.llmProviderSettings[.anthropic]?.apiKey {
-          if let key = userDefaults.loadSecuredValue(forKey: anthropicAPIKey) {
-            settings.llmProviderSettings[.anthropic]?.apiKey = key
-          } else {
-            settings.llmProviderSettings.removeValue(forKey: .anthropic)
-          }
-        }
-        if let openAIAPIKey = settings.llmProviderSettings[.openAI]?.apiKey {
-          if let key = userDefaults.loadSecuredValue(forKey: openAIAPIKey) {
-            settings.llmProviderSettings[.openAI]?.apiKey = key
-          } else {
-            settings.llmProviderSettings.removeValue(forKey: .openAI)
-          }
-        }
-        if let openRouterAPIKey = settings.llmProviderSettings[.openRouter]?.apiKey {
-          if let key = userDefaults.loadSecuredValue(forKey: openRouterAPIKey) {
-            settings.llmProviderSettings[.openRouter]?.apiKey = key
-          } else {
-            settings.llmProviderSettings.removeValue(forKey: .openRouter)
+        // Load API keys from the keychain.
+        for provider in LLMProvider.allCases {
+          if let apiKey = settings.llmProviderSettings[provider]?.apiKey {
+            if let key = userDefaults.loadSecuredValue(forKey: apiKey) {
+              settings.llmProviderSettings[provider]?.apiKey = key
+            } else {
+              settings.llmProviderSettings.removeValue(forKey: provider)
+            }
           }
         }
 


### PR DESCRIPTION
Several fixes:
- handle request cancellation with Xcode 26
- Fix serialization of several AI providers, including Gemini
- Fix runtime error when using a Publisher that is not bound to the main thread in SwiftUI
- Detecting current tab when Xcode is in tabless mode (seems more frequent in Xcode 26)