### PR TITLE
Make sure to install yarn via homebrew during setup

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -19,6 +19,8 @@ brew install --cask swiftformat-for-xcode
 brew install jc
 brew install jq
 brew install shfmt
+brew install yarn
+
 cp -R ./tools/githooks/. .git/hooks
 
 # helper for dev tools to bashrc


### PR DESCRIPTION
yarn is used in several places, e.g `sync-js-bundle-to-app.sh`, but wasn't installed during setup. This may cause issues later on, for example while trying to build the app for the first time.

Fix by adding instruction to install it during setup.