### PR TITLE
Update shfmt cmd in the pre-commit githook to correctly search for all shell files

### DIFF
--- a/tools/githooks/pre-commit
+++ b/tools/githooks/pre-commit
@@ -9,8 +9,8 @@ repo_root=$(git rev-parse --show-toplevel)
 current_dir=$(pwd)
 
 if [ -z "$repo_root" ]; then
-    echo "Not a git repository"
-    exit 1
+	echo "Not a git repository"
+	exit 1
 fi
 
 # Get current diff
@@ -27,7 +27,7 @@ cd "$repo_root"
 
 cd "$repo_root"
 # lint .sh files
-shfmt -w ./**/*.sh
+shfmt -w .
 
 # Check for created changes
 new_diff=$(git diff HEAD)
@@ -36,8 +36,8 @@ cd "$current_dir"
 
 # If there are new changes, ask to re-commit
 if [ "$new_diff" != "$current_diff" ]; then
-    echo "Changes detected after running pre-commit hooks. Please review the changes."
-    exit 1
+	echo "Changes detected after running pre-commit hooks. Please review the changes."
+	exit 1
 else
-    echo "No changes detected after running pre-commit hooks."
+	echo "No changes detected after running pre-commit hooks."
 fi


### PR DESCRIPTION
The current `shfmt -w ./**/*.sh` cmd failed consistently on my machine. The error message was "lstat ./**/*.sh: no such file or directory". I think it searched for a file with that name, literally.

Fix by giving `shfmt` the current dir. This should work because its documentary states that "If a given path is a directory, all shell scripts found under that directory will be used". Also tested with `shfmt -f .` and all shell files in the project were listed.