### PR TITLE
DefaultFileSuggestionService to correctly resolve absolute paths of files in groups

### DIFF
--- a/app/modules/services/FileSuggestionService/Sources/DefaultFileSuggestionService.swift
+++ b/app/modules/services/FileSuggestionService/Sources/DefaultFileSuggestionService.swift
@@ -165,9 +165,16 @@ final class DefaultFileSuggestionService: FileSuggestionService {
     var files = [URL]()
     let addFileRef: (PBXFileReference) -> Void = { fileRef in
       if
-        let path = fileRef.path.map({ $0.resolvePath(from: projectDir) }),
+        var path = URL(string: fileRef.path ?? ""),
         !["app", "appex", "framework"].contains(path.pathExtension)
       {
+        var parent = fileRef.parent
+        while let parentPath = URL(string: parent?.path ?? "") {
+          path = path.resolve(from: parentPath)
+          parent = parent?.parent
+        }
+        path = path.resolve(from: projectDir)
+
         if fileRef.lastKnownFileType == "wrapper" {
           files.append(contentsOf: self.listFilesAvailable(inDirectory: path))
         } else {

--- a/app/modules/services/FileSuggestionService/Sources/DefaultFileSuggestionService.swift
+++ b/app/modules/services/FileSuggestionService/Sources/DefaultFileSuggestionService.swift
@@ -165,14 +165,19 @@ final class DefaultFileSuggestionService: FileSuggestionService {
     var files = [URL]()
     let addFileRef: (PBXFileReference) -> Void = { fileRef in
       if
-        var path = URL(string: fileRef.path ?? ""),
+        let pathStr = fileRef.path,
+        var path = URL(string: pathStr),
         !["app", "appex", "framework"].contains(path.pathExtension)
       {
         var parent = fileRef.parent
-        while let parentPath = URL(string: parent?.path ?? "") {
+        while
+          let parentPathStr = parent?.path,
+          let parentPath = URL(string: parentPathStr)
+        {
           path = path.resolve(from: parentPath)
           parent = parent?.parent
         }
+
         path = path.resolve(from: projectDir)
 
         if fileRef.lastKnownFileType == "wrapper" {

--- a/app/modules/services/FileSuggestionService/Tests/resources/TestXcodeProjParsing/TestXcodeProjParsing.xcodeproj/project.pbxproj
+++ b/app/modules/services/FileSuggestionService/Tests/resources/TestXcodeProjParsing/TestXcodeProjParsing.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05E0FE242E8459E80022C845 /* TestXcodeProjParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E0FE232E8459E80022C845 /* TestXcodeProjParsingTests.swift */; };
 		F680D0C32DC0458F00EA0CD5 /* Atomic in Frameworks */ = {isa = PBXBuildFile; productRef = F680D0C22DC0458F00EA0CD5 /* Atomic */; };
 /* End PBXBuildFile section */
 
@@ -21,6 +22,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		05E0FE232E8459E80022C845 /* TestXcodeProjParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestXcodeProjParsingTests.swift; sourceTree = "<group>"; };
 		F680D0642DC044CB00EA0CD5 /* TestXcodeProjParsing.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestXcodeProjParsing.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F680D0752DC044CC00EA0CD5 /* TestXcodeProjParsingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestXcodeProjParsingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -29,11 +31,6 @@
 		F680D0662DC044CB00EA0CD5 /* TestXcodeProjParsing */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = TestXcodeProjParsing;
-			sourceTree = "<group>";
-		};
-		F680D0782DC044CC00EA0CD5 /* TestXcodeProjParsingTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = TestXcodeProjParsingTests;
 			sourceTree = "<group>";
 		};
 		F680D0822DC044CC00EA0CD5 /* TestXcodeProjParsingUITests */ = {
@@ -62,11 +59,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		05E0FE252E8459F70022C845 /* TestXcodeProjParsingTests */ = {
+			isa = PBXGroup;
+			children = (
+				05E0FE232E8459E80022C845 /* TestXcodeProjParsingTests.swift */,
+			);
+			path = TestXcodeProjParsingTests;
+			sourceTree = "<group>";
+		};
 		F680D05B2DC044CB00EA0CD5 = {
 			isa = PBXGroup;
 			children = (
 				F680D0662DC044CB00EA0CD5 /* TestXcodeProjParsing */,
-				F680D0782DC044CC00EA0CD5 /* TestXcodeProjParsingTests */,
+				05E0FE252E8459F70022C845 /* TestXcodeProjParsingTests */,
 				F680D0822DC044CC00EA0CD5 /* TestXcodeProjParsingUITests */,
 				F680D0652DC044CB00EA0CD5 /* Products */,
 			);
@@ -119,9 +124,6 @@
 			);
 			dependencies = (
 				F680D0772DC044CC00EA0CD5 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				F680D0782DC044CC00EA0CD5 /* TestXcodeProjParsingTests */,
 			);
 			name = TestXcodeProjParsingTests;
 			packageProductDependencies = (
@@ -201,6 +203,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				05E0FE242E8459E80022C845 /* TestXcodeProjParsingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I frequently ran into the assertion at [ChatInputViewModel.swift#L546](https://github.com/getcmd-dev/cmd/blob/2f07e188cb60e062deed2e02488080eea6252b48/app/modules/features/Chat/ChatFeature/Sources/Input/ChatInputViewModel.swift#L546) while trying out cmd with a project I'm working on. It turned out that the paths that belong to `FileSuggestion`s returned by `DefaultFileSuggestionService` were invalid for many files. They all missed the sub-dirs inside the project's root.

After some more digging, I found out that `PBXFileReference`'s path is relative to the project's root dir only if the file is organized in a buildable Folder (introduced in Xcode 16). If a file is within a Group, the file ref's path only contains the file name. So we need to walk up the hierarchy all the way to the root dir to construct the relative path.

This PR does that, and updates tests to prevent this issue from happening again in the future.