### PR TITLE
Correctly construct globalSettingsLocation in DefaultSettingsService

### DIFF
--- a/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
+++ b/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
@@ -98,8 +98,8 @@ final class DefaultSettingsService: SettingsService {
   private let sharedUserDefaults: UserDefaultsI
   private let releaseSharedUserDefaults: UserDefaultsI?
 
-  private var globalSettingsLocation: FilePath {
-    "~/.cmd/settings.json"
+  private var globalSettingsLocation: URL {
+    fileManager.homeDirectoryForCurrentUser.appending(path: ".cmd/settings.json")
   }
 
   private func loadSettings() -> Settings {
@@ -122,7 +122,7 @@ final class DefaultSettingsService: SettingsService {
     internalSettings.pointReleaseXcodeExtensionToDebugApp = sharedUserDefaults
       .bool(forKey: SharedKeys.pointReleaseXcodeExtensionToDebugApp)
 
-    var externalSettings: ExternalSettings = (try? fileManager.read(dataFrom: URL(filePath: globalSettingsLocation)!))
+    var externalSettings: ExternalSettings = (try? fileManager.read(dataFrom: globalSettingsLocation))
       .map { data in
         do {
           return try JSONDecoder().decode(ExternalSettings.self, from: data)

--- a/app/modules/services/SettingsService/Sources/ExternalSettings.swift
+++ b/app/modules/services/SettingsService/Sources/ExternalSettings.swift
@@ -197,16 +197,17 @@ extension Encodable {
   /// Write the object to the desired location.
   /// Only write entries that either have a non-default value, or already that exist in the file.
   /// If a file already exist at the target location, all existing keys that are not key of the new object are preserved.
-  func writeNonDefaultValues(to path: FilePath, fileManager: FileManagerI) throws {
-    let fileUrl = URL(filePath: path.string)
-    try fileManager.createDirectories(requiredForFileAt: fileUrl)
+  func writeNonDefaultValues(to url: URL, fileManager: FileManagerI) throws {
+    try fileManager.createDirectories(requiredForFileAt: url)
 
-    if !fileManager.fileExists(atPath: path.string) {
+    if
+      !fileManager.fileExists(atPath: url.absoluteString)
+    {
       let encoder = JSONEncoder()
       encoder.userInfo[.doNotEncodeDefaultValues] = true
       encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
       let data = try encoder.encode(self)
-      try fileManager.write(data: data, to: fileUrl)
+      try fileManager.write(data: data, to: url)
       return
     }
     // If a file exist:
@@ -222,7 +223,7 @@ extension Encodable {
     let partiallyEncodedData = try partialEncoder.encode(self)
     let partiallyEncoded = try JSONSerialization.jsonObject(with: partiallyEncodedData) as? [String: Any]
     let existing = try? {
-      let data = try fileManager.read(dataFrom: fileUrl)
+      let data = try fileManager.read(dataFrom: url)
       return try JSONSerialization.jsonObject(with: data) as? [String: Any]
     }()
     var merged = existing ?? [:]
@@ -235,7 +236,7 @@ extension Encodable {
       }
     }
     let mergedData = try JSONSerialization.data(withJSONObject: merged, options: [.prettyPrinted, .sortedKeys])
-    try fileManager.write(data: mergedData, to: fileUrl)
+    try fileManager.write(data: mergedData, to: url)
   }
 }
 

--- a/app/modules/services/SettingsService/Sources/ExternalSettings.swift
+++ b/app/modules/services/SettingsService/Sources/ExternalSettings.swift
@@ -200,9 +200,7 @@ extension Encodable {
   func writeNonDefaultValues(to url: URL, fileManager: FileManagerI) throws {
     try fileManager.createDirectories(requiredForFileAt: url)
 
-    if
-      !fileManager.fileExists(atPath: url.absoluteString)
-    {
+    if !fileManager.fileExists(atPath: url.absoluteString) {
       let encoder = JSONEncoder()
       encoder.userInfo[.doNotEncodeDefaultValues] = true
       encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/app/modules/services/SettingsService/Sources/ExternalSettings.swift
+++ b/app/modules/services/SettingsService/Sources/ExternalSettings.swift
@@ -200,7 +200,7 @@ extension Encodable {
   func writeNonDefaultValues(to url: URL, fileManager: FileManagerI) throws {
     try fileManager.createDirectories(requiredForFileAt: url)
 
-    if !fileManager.fileExists(atPath: url.absoluteString) {
+    if !fileManager.fileExists(atPath: url.path) {
       let encoder = JSONEncoder()
       encoder.userInfo[.doNotEncodeDefaultValues] = true
       encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/app/modules/services/SettingsService/Tests/PartialEncodingTests.swift
+++ b/app/modules/services/SettingsService/Tests/PartialEncodingTests.swift
@@ -45,10 +45,10 @@ struct PartialEncodingTests {
     func test_writeNonDefaultValues_writesOnlyNonDefaultValues_whenNoFileExisted() async throws {
       let settings = ExternalSettings(allowAnonymousAnalytics: false)
       let fileManager = MockFileManager()
-      let filePath = FilePath("/path/to/settings.json")
-      try settings.writeNonDefaultValues(to: filePath, fileManager: fileManager)
+      let fileURL = URL(filePath: "/path/to/settings.json")
+      try settings.writeNonDefaultValues(to: fileURL, fileManager: fileManager)
       let file = try #require(fileManager.files.first)
-      #expect(file.key.standardized.absoluteString == "file:///path/to/settings.json")
+      #expect(file.key.standardized.path == "/path/to/settings.json")
       file.value.expectToMatch("""
         {
             "allowAnonymousAnalytics": false
@@ -59,17 +59,17 @@ struct PartialEncodingTests {
     @Test
     func test_writeDefaultValuesWhoseKeysAlreadyExisted() async throws {
       let settings = ExternalSettings(allowAnonymousAnalytics: false)
-      let filePath = FilePath("/path/to/settings.json")
+      let fileURL = URL(filePath: "/path/to/settings.json")
       let fileManager = MockFileManager(files: [
-        filePath.string: """
+        fileURL.path: """
           {
               "automaticallyCheckForUpdates": false
           }
           """,
       ])
-      try settings.writeNonDefaultValues(to: filePath, fileManager: fileManager)
+      try settings.writeNonDefaultValues(to: fileURL, fileManager: fileManager)
       let file = try #require(fileManager.files.first)
-      #expect(file.key.standardized.absoluteString == "file:///path/to/settings.json")
+      #expect(file.key.standardized.path == "/path/to/settings.json")
       file.value.expectToMatch("""
         {
             "allowAnonymousAnalytics": false,
@@ -81,17 +81,17 @@ struct PartialEncodingTests {
     @Test
     func test_keepsNonOverlappingExistingValues() async throws {
       let settings = ExternalSettings(allowAnonymousAnalytics: false)
-      let filePath = FilePath("/path/to/settings.json")
+      let fileURL = URL(filePath: "/path/to/settings.json")
       let fileManager = MockFileManager(files: [
-        filePath.string: """
+        fileURL.path: """
           {
               "someUnknownProperty": 1
           }
           """,
       ])
-      try settings.writeNonDefaultValues(to: filePath, fileManager: fileManager)
+      try settings.writeNonDefaultValues(to: fileURL, fileManager: fileManager)
       let file = try #require(fileManager.files.first)
-      #expect(file.key.standardized.absoluteString == "file:///path/to/settings.json")
+      #expect(file.key.standardized.path == "/path/to/settings.json")
       file.value.expectToMatch("""
         {
             "allowAnonymousAnalytics": false,


### PR DESCRIPTION
Repeatedly ran into write permission issue while trying to save an LLM API key. This is because `DefaultSettingsService` failed to properly resolve the current user's home dir and thus was trying to write to `/~/.cmd` which belongs to the root dir.

Fix by constructing `globalSettingsLocation` using `FileManager`'s `homeDirectoryForCurrentUser`.