### PR TITLE
Upgrade Claude sonnet to 4.5

### DIFF
--- a/app/modules/foundations/LLMFoundation/Sources/providers/Anthropic.swift
+++ b/app/modules/foundations/LLMFoundation/Sources/providers/Anthropic.swift
@@ -20,7 +20,7 @@ extension LLMProvider {
     idForModel: { model in
       switch model {
       case .claudeHaiku_3_5: return "claude-3-5-haiku-latest"
-      case .claudeSonnet: return "claude-sonnet-4-20250514"
+      case .claudeSonnet: return "claude-sonnet-4-5-20250929"
       case .claudeOpus: return "claude-opus-4-1-20250805"
       default: throw AppError(message: "Model \(model) is not supported by Anthropic provider.")
       }

--- a/app/modules/foundations/LLMFoundation/Sources/providers/OpenRouter.swift
+++ b/app/modules/foundations/LLMFoundation/Sources/providers/OpenRouter.swift
@@ -23,7 +23,7 @@ extension LLMProvider {
     idForModel: { model in
       switch model {
       case .claudeHaiku_3_5: return "anthropic/claude-3.5-haiku"
-      case .claudeSonnet: return "anthropic/claude-sonnet-4"
+      case .claudeSonnet: return "anthropic/claude-sonnet-4.5"
       case .claudeOpus: return "anthropic/claude-opus-4.1"
       case .gpt: return "openai/gpt-5"
       case .gpt_mini: return "openai/gpt-5-mini"


### PR DESCRIPTION
As the new model have the same price as 4.1, and is considered better across the board, simply upgrade `claudeSonnet` instead of making a new distinct version available