### PR TITLE
Only pull releases from the correct Sparkle channel (only stable for now)

### DIFF
--- a/app/command.shared.xcconfig
+++ b/app/command.shared.xcconfig
@@ -9,4 +9,7 @@ INFOPLIST_KEY_DebugUserDefaultsSharedSuiteName = $(DEBUG_SHARED_USER_DEFAULTS_SU
 APP_VERSION=0.1.21
 MARKETING_VERSION=$(APP_VERSION)
 
+// App type maps to Sparkle update channel (e.g., "stable" or "dev")
+APP_DISTRIBUTION_CHANNEL=dev
+
 RELEASE_APP_BUNDLE_IDENTIFIER = dev.getcmd.command

--- a/app/command/Info.plist
+++ b/app/command/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>APP_BUNDLE_IDENTIFIER</key>
 	<string>$(HOST_APP_BUNDLE_IDENTIFIER)</string>
+	<key>APP_DISTRIBUTION_CHANNEL</key>
+	<string>$(APP_DISTRIBUTION_CHANNEL)</string>
 	<key>DebugUserDefaultsSharedSuiteName</key>
 	<string>$(INFOPLIST_KEY_DebugUserDefaultsSharedSuiteName)</string>
 	<key>RELEASE_APP_BUNDLE_IDENTIFIER</key>

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -115,8 +115,6 @@ platform :mac do
 
     # Create a new build
     sh("rm -rf #{build_path}")
-    # Resolve package dependencies first. This is to work around an issue where CI would freeze.
-    sh("xcodebuild -resolvePackageDependencies -scheme command -project ../command.xcodeproj -configuration Release -derivedDataPath #{build_path}/derived_data -onlyUsePackageVersionsFromResolvedFile -parallelizeTargets")
     sh("../tools/release/configure_xcodeproj_for_release_build.sh")
 
     build_mac_app(
@@ -204,7 +202,10 @@ platform :mac do
     skip_github_release = !options[:skip_github_release].nil?
 
     setup_ci if ENV["CI"]
+    # Set APP_DISTRIBUTION_CHANNEL to stable for release builds
     app_config_path = File.absolute_path("../command.shared.xcconfig")
+    sh("sed -i '' 's/APP_DISTRIBUTION_CHANNEL=.*/APP_DISTRIBUTION_CHANNEL=stable/' #{app_config_path}")
+
     version = sh("cat #{app_config_path} | grep APP_VERSION=").split("APP_VERSION=").last.strip
     # Look for an existing version tag. If one exist, bump the version.
     existing_version = sh("git ls-remote origin refs/tags/v#{version}").strip

--- a/app/modules/foundations/AppFoundation/Sources/Bundle+Build.swift
+++ b/app/modules/foundations/AppFoundation/Sources/Bundle+Build.swift
@@ -20,6 +20,11 @@ extension Bundle {
   public var releaseHostAppBundleId: String {
     infoDictionary?["RELEASE_APP_BUNDLE_IDENTIFIER"] as? String ?? "dev.getcmd.command"
   }
+
+  /// The app type, which maps to the Sparkle update channel (e.g., "stable" or "dev")
+  public var appType: String {
+    infoDictionary?["APP_DISTRIBUTION_CHANNEL"] as? String ?? "stable"
+  }
 }
 
 extension String {

--- a/app/modules/services/AppUpdateService/Sources/DefaultAppUpdateService.swift
+++ b/app/modules/services/AppUpdateService/Sources/DefaultAppUpdateService.swift
@@ -202,6 +202,13 @@ final class UpdateChecker: NSObject, Sendable {
 // MARK: SPUUpdaterDelegate
 
 extension UpdateChecker: SPUUpdaterDelegate {
+
+  func allowedChannels(for _: SPUUpdater) -> Set<String> {
+    let channel = Bundle.main.appType
+    updateLogger.info("allowedChannels(for:) - using channel: \(channel)")
+    return [channel]
+  }
+
   func updaterShouldPromptForPermissionToCheck(forUpdates _: SPUUpdater) -> Bool {
     updateLogger.info("updaterShouldPromptForPermissionToCheck(forUpdates:)")
     return false


### PR DESCRIPTION
I'd like to introduce a dev branch / nightly builds to keep the main release stable while releasing often (and use dogfooding of the dev branch to improve the stability of the main channel).

This might as well be done with using different branches, but making sure we're taking the update from the right channel seems more future proof anyway

Relevant to understand this configuration is the homebrew config: https://github.com/Homebrew/homebrew-cask/blob/main/Casks/c/cmd.rb