### PR TITLE
Focus tests, improved xcode gen, and Claude.md

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -8,3 +8,6 @@ The MacOS app is built mostly with Swift 6 / SwiftUI. It embedes a local typescr
 - Make sure to write meaningful tests whenever relevant but don't write tests that are straightforward (ex: testing a default value). Verify that those new tests pass.
 - Make sure to verify that the code compiles.
 - Respect the existing modularization structure.
+
+## App
+When modifying files in `./app` be sure to first read `./app/Claude.md`

--- a/app/Claude.md
+++ b/app/Claude.md
@@ -1,11 +1,52 @@
+## Instructions
+Note: you might see existing code that doesn't follow the patterns described here. Do not restructure this pre-existing code unless specifically instructed.
+
+### Tests
+- Use Swift Testing, never use XCTest
+- To run tests, prefer to use `./cmd.sh test:swift`, or to run tests for a single module: `./cmd.sh test:swift --module LLMService`. (./cmd.sh is to be run from the root of this repo, ie at `../` from this file's location)
+- When editing tests, you should ALWAYS make sure the tests for the corresponding module run.
+- When testing JSON payloads, be sure to look at the `JSONTestHelpers`
+- When testing async code, use the `expectaction` from `SwiftTesting`
+- When testing @Observable objects, use `wait` from `Observable+onChange` of helpers from `Observable+helpers.swift`
+- When working with a class that has dependencies:
+  * always import `DependenciesTestSupport`. This will ensure each test is injected with isolated dependencies.
+  * When relevant, prefer to define and use a helper to set default dependencies on the test suite:
+```swift
+@Suite("LLMSettingsViewModelTests", .dependencies { $0.setDefaulfMockValues() }) { ... }
+extension DependencyValues {
+  fileprivate mutating func setDefaulfMockValues() {
+    llmService = MockLLMService()
+    settingsService = MockSettingsService()
+  }
+}
+```
+  * When setting **initial** properties for a dependency to use the syntax
+```swift
+@Test("some test", .dependencies {
+  $0.llmService = MockLLMService(availableModels: [...])
+})
+```
+over using `withDependencies` within the function code.
+  * When stubbing method calls, or needing to access the dependency within the test function, do this as so:
+```swift
+@Test("some test", .dependencies {
+  $0.llmService = MockLLMService(availableModels: [...])
+})
+func something() async throws {
+  @Dependency(\.llmService) var llmService
+  let mockLLMService = try #require(llmService as? MockLLMService)
+  mockLLMService.onFetchModels = ...
+}
+- Never use force unwrapping. Either use `try #require(...)` or `guard` / `throw`.
+```
 
 ## Coding style
 ### Tests
-Whenever possible, use `sut` (system under test) to name the object being tested.
-Try to organize each test with given/when/then sections, marked by comments ex:
+- Whenever possible, use `sut` (system under test) to name the object being tested.
+- Try to organize each test with given/when/then sections, marked by comments ex:
 ```swift
 @MainActor @Test("Is not called when a non-observed property changes")
-    func test_didSet_isNotCalledWhenNonObservedPropertyChanges() async throws {
+    func didSet_isNotCalledWhenNonObservedPropertyChanges() async throws {
       // given
       let sut = ObservableValue(int: 1)
       let receivedValues = Atomic<[Int]>([])
@@ -24,3 +65,4 @@ Try to organize each test with given/when/then sections, marked by comments ex:
     }
   }
 ```
+- Since you're using `@Test`, function names do not need to start with `test_`

--- a/app/Claude.md
+++ b/app/Claude.md
@@ -12,9 +12,9 @@ Note: you might see existing code that doesn't follow the patterns described her
   * always import `DependenciesTestSupport`. This will ensure each test is injected with isolated dependencies.
   * When relevant, prefer to define and use a helper to set default dependencies on the test suite:
 ```swift
-@Suite("LLMSettingsViewModelTests", .dependencies { $0.setDefaulfMockValues() }) { ... }
+@Suite("LLMSettingsViewModelTests", .dependencies { $0.setDefaultMockValues() }) { ... }
 extension DependencyValues {
-  fileprivate mutating func setDefaulfMockValues() {
+  fileprivate mutating func setDefaultMockValues() {
     llmService = MockLLMService()
     settingsService = MockSettingsService()
   }
@@ -37,8 +37,8 @@ func something() async throws {
   let mockLLMService = try #require(llmService as? MockLLMService)
   mockLLMService.onFetchModels = ...
 }
-- Never use force unwrapping. Either use `try #require(...)` or `guard` / `throw`.
 ```
+- Never use force unwrapping. Either use `try #require(...)` or `guard` / `throw`.
 
 ## Coding style
 ### Tests

--- a/app/contributing.md
+++ b/app/contributing.md
@@ -39,7 +39,7 @@ You can focus on just one module and its dependencies. This can allow for really
 
 To do so:
 - Close open Xcode windows that might overlap with what you will focus on.
-- Run `cmd focus --module <module name, e.g. 'AppFoundation'>` (you can run `cmd focus --list` to see all the available modules).
+- Run `cmd focus --module <module name, e.g. 'AppFoundation'> --open` (you can run `cmd focus --list` to see all the available modules).
 - ⚠️ When done, use `cmd open:app` to open the app's xcodeproj. This does some clean up that is important as Xcode doesn't like some of the artifacts created by local Swift packages, and will not show your files in the file hierarchy anymore.
 
 ### Setup to run release script locally

--- a/app/tools/dependencies/focus.sh
+++ b/app/tools/dependencies/focus.sh
@@ -7,6 +7,17 @@ CURRENT_DIR="$(pwd)"
 
 cd "${ROOT_DIR}/app/tools/dependencies"
 
+# Parse input flags
+should_open_in_xcode=false
+parsed_args=()
+for arg in "$@"; do
+	if [ "$arg" = "--open" ]; then
+		should_open_in_xcode=true
+	else
+		parsed_args+=("$arg")
+	fi
+done
+
 # Cache the built binary, as for some reasons it gets rebuilt every time otherwise.
 # The cache will need to be manually cleaned if the binary is updated.
 if [ ! -f "./tmp/bin/sync-package-dependencies" ]; then
@@ -16,20 +27,7 @@ if [ ! -f "./tmp/bin/sync-package-dependencies" ]; then
 	cp ".build/release/SyncPackageDependenciesCommand" "./tmp/bin/sync-package-dependencies"
 fi
 
-# If --list is provided, list the packages and exit
-if [[ "$*" == *"--list"* ]]; then
-	./tmp/bin/sync-package-dependencies focus --path "${ROOT_DIR}/app/modules/Package.swift" "$@"
-
-	# lint Package.swift / Module.swift
-	cd "${ROOT_DIR}/app"
-	mkdir -p .build/caches/swiftformat
-	swiftformat --config rules.swiftformat ./**/Module.swift --cache .build/caches/swiftformat --quiet
-	swiftformat --config rules.swiftformat ./**/Package.swift --cache .build/caches/swiftformat --quiet
-
-	exit 0
-fi
-
-package_path_for_module=$("./tmp/bin/sync-package-dependencies" focus --path "${ROOT_DIR}/app/modules/Package.swift" "$@")
+output=$("./tmp/bin/sync-package-dependencies" focus --path "${ROOT_DIR}/app/modules/Package.swift" "${parsed_args[@]}")
 
 # lint Package.swift / Module.swift
 cd "${ROOT_DIR}/app"
@@ -37,10 +35,22 @@ mkdir -p .build/caches/swiftformat
 swiftformat --config rules.swiftformat ./**/Module.swift --cache .build/caches/swiftformat --quiet
 swiftformat --config rules.swiftformat ./**/Package.swift --cache .build/caches/swiftformat --quiet
 
-# open the package in xcode
-xcode_path=$(xcode-select -p)
-xcode_path="${xcode_path%%.app*}.app"
-echo "Opening package at: ${package_path_for_module}"
-# Tell Xcode to not re-open windows that were open when it quit,
-# to avoid having several windows using the same files which Xcode doesn't support.
-open -a "$xcode_path" "$package_path_for_module" --args -ApplePersistenceIgnoreState YES
+# If --list is provided, list the packages and exit
+if [[ "$*" == *"--list"* ]]; then
+	echo $output
+	exit 0
+fi
+
+if [ "$should_open_in_xcode" = true ]; then
+	package_path_for_module=$output
+	# open the package in xcode
+	xcode_path=$(xcode-select -p)
+	xcode_path="${xcode_path%%.app*}.app"
+	echo "Opening package at: ${package_path_for_module}"
+	# Tell Xcode to not re-open windows that were open when it quit,
+	# to avoid having several windows using the same files which Xcode doesn't support.
+	open -a "$xcode_path" "$package_path_for_module" --args -ApplePersistenceIgnoreState YES
+	echo "👉 Don't forget to use 'cmd open:app' the next time you re-open the app's xcodeproj, instead of opening it manually."
+else
+	echo $output
+fi

--- a/cmd.sh
+++ b/cmd.sh
@@ -12,7 +12,6 @@ lint_swift_command() {
 	install_swiftformat
 	# files: if an arg is provided use it, otherwise .
 	# convert arg to a relative path from app/
-	echo $1 >~/Downloads/tmp.log
 	if [ -z "$1" ]; then
 		files="."
 	else
@@ -62,12 +61,13 @@ close_xcode() {
 
 focus_dependency_command() {
 	cd "$(git rev-parse --show-toplevel)/app"
-	close_xcode
+	if [ "$SKIP_CLOSE_XCODE" != "true" ]; then
+		close_xcode
+	fi
 	# Reset xcode state
 	find . -path '*.xcuserstate' 2>/dev/null | git check-ignore --stdin | xargs -I{} rm {}
 
 	./tools/dependencies/focus.sh "$@"
-	echo "👉 Don't forget to use 'cmd open:app' the next time you re-open the app's xcodeproj, instead of opening it manually."
 }
 
 build_release_command() {
@@ -117,6 +117,9 @@ install_swiftformat() {
 	echo "✅ swiftformat $($SWIFTFORMAT_PATH --version) installed at $target_path."
 }
 
+# Xcode has a weird bug where when opening the Xcode project it will not show most files.
+# This seems to happen when there's lingering files from nested Swift packages.
+# This function attempts to remove such files.
 clean_command() {
 	# Signal to the file watcher that is should not regenerate files.
 	touch "$(git rev-parse --show-toplevel)/.build/disable-watcher"
@@ -126,23 +129,40 @@ clean_command() {
 	cd "$(git rev-parse --show-toplevel)/app/modules"
 
 	# Remove derived files from swift packages
-	swift package clean
+	find . -type d -name '.build' -exec sh -c 'rm -rf "$1"' _ {} \; 2>/dev/null
 	find . -not -path './.git/*' 2>/dev/null |
-		# Don't remove files in ./services/LocalServerService/Sources/Resources
-		grep -v 'services/LocalServerService/Sources/Resources' |
-		# Remove all git-ignored files
 		git check-ignore --stdin |
+		grep 'Package.swift\|Package.resolved' |
 		while read file; do rm -rf "$file"; done
-	# Reset xcode state
-	cd "$(git rev-parse --show-toplevel)/app" &&
-		find . -path '*.xcuserstate' 2>/dev/null | git check-ignore --stdin | xargs -I{} rm {}
 
 	# Remove lock file
 	rm "$(git rev-parse --show-toplevel)/.build/disable-watcher"
 }
 
 test_swift_command() {
-	cd "$(git rev-parse --show-toplevel)/app/modules" && swift test -Xswiftc -suppress-warnings --quiet --no-parallel "$@"
+	# Extract --module value if provided
+	focussed_module=""
+	parsed_args=()
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--module)
+			focussed_module="$2"
+			shift 2 # Skip both --module and its value
+			;;
+		*)
+			parsed_args+=("$1")
+			shift
+			;;
+		esac
+	done
+	if [ -n "$focussed_module" ]; then
+		SKIP_CLOSE_XCODE=true package_swift=$(focus_dependency_command --module "$focussed_module")
+		cd $(dirname $package_swift) && swift test -Xswiftc -suppress-warnings --quiet --no-parallel "${parsed_args[@]}"
+	else
+		# run all tests
+		cd "$(git rev-parse --show-toplevel)/app/modules" && swift test -Xswiftc -suppress-warnings --quiet --no-parallel "${parsed_args[@]}"
+	fi
 }
 
 test_ts_command() {

--- a/cmd.sh
+++ b/cmd.sh
@@ -158,7 +158,7 @@ test_swift_command() {
 	done
 	if [ -n "$focussed_module" ]; then
 		SKIP_CLOSE_XCODE=true package_swift=$(focus_dependency_command --module "$focussed_module")
-		cd $(dirname $package_swift) && swift test -Xswiftc -suppress-warnings --quiet --no-parallel "${parsed_args[@]}"
+		cd "$(dirname $package_swift)" && swift test -Xswiftc -suppress-warnings --quiet --no-parallel "${parsed_args[@]}"
 	else
 		# run all tests
 		cd "$(git rev-parse --show-toplevel)/app/modules" && swift test -Xswiftc -suppress-warnings --quiet --no-parallel "${parsed_args[@]}"


### PR DESCRIPTION
- Support running tests for only one module, and only building its dependencies: `cmd test:swift --module SettingsService`. This is faster than using `swift test` over the main `Package.swift`, especially for modules with few dependencies, since modules that are not dependencies are not loaded nor built
- changed `cmd focus` to by default not close / open Xcode. Now it's opt-in: `cmd focus --module SettingsService --open`
- Update documentation
- Improve Claude.md, especially regarding testing guidelines