### PR TITLE
Better handle non standard spacing in ThreadSade macro

### DIFF
--- a/app/modules/macros/ThreadSafe/Macro/ThreadSafe.swift
+++ b/app/modules/macros/ThreadSafe/Macro/ThreadSafe.swift
@@ -267,7 +267,8 @@ extension ThreadSafeInitializerMacro: BodyMacro {
     return statements.compactMap(\.self)
   }
 
-  /// Regex to match "self.key = "
+  /// Regex to match "self.key = " with flexible whitespace
+  /// Handles standard spacing, multiple spaces, tabs, etc.
   private static func selfDotPropertyEqual(
     _ propertyName: String,
     isAtStart: Bool = false)
@@ -291,7 +292,8 @@ extension ThreadSafeInitializerMacro: BodyMacro {
     }
   }
 
-  /// Regex to match "key = "
+  /// Regex to match "key = " with flexible whitespace
+  /// Handles standard spacing, multiple spaces, tabs, etc.
   private static func propertyEqual(_ propertyName: String, isAtStart: Bool = false) -> Regex<Regex<Substring>.RegexOutput> {
     if isAtStart {
       Regex {

--- a/app/modules/macros/ThreadSafe/Macro/ThreadSafe.swift
+++ b/app/modules/macros/ThreadSafe/Macro/ThreadSafe.swift
@@ -2,6 +2,7 @@
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 import Foundation
+import RegexBuilder
 import SwiftCompilerPlugin
 import SwiftDiagnostics
 import SwiftSyntax
@@ -213,8 +214,8 @@ extension ThreadSafeInitializerMacro: BodyMacro {
       for (key, _, _) in storedVariables.filter({ $0.defaultValue == nil }) {
         let trimmedStatement = statement.description.trimmingCharacters(in: .whitespacesAndNewlines)
         if
-          trimmedStatement.starts(with: "self.\(key) = ") ||
-          trimmedStatement.starts(with: "\(key) = ")
+          trimmedStatement.contains(selfDotPropertyEqual(key, isAtStart: true)) ||
+          trimmedStatement.contains(propertyEqual(key, isAtStart: true))
         {
           return (offset: offset, element: key)
         }
@@ -230,16 +231,16 @@ extension ThreadSafeInitializerMacro: BodyMacro {
       }
       let trimmedStatement = statement.description.trimmingCharacters(in: .whitespacesAndNewlines)
       for (key, _, _) in storedVariables {
-        if trimmedStatement.starts(with: "self.\(key) = ") {
+        if trimmedStatement.contains(selfDotPropertyEqual(key, isAtStart: true)) {
           mutatedProperties.insert(key)
           return [
-            CodeBlockItemSyntax(stringLiteral: statement.description.replacing("self.\(key) = ", with: "_\(key) = ")),
+            CodeBlockItemSyntax(stringLiteral: statement.description.replacing(selfDotPropertyEqual(key), with: "_\(key) =")),
           ]
         }
-        if trimmedStatement.starts(with: "\(key) = ") {
+        if trimmedStatement.contains(propertyEqual(key, isAtStart: true)) {
           mutatedProperties.insert(key)
           return [
-            CodeBlockItemSyntax(stringLiteral: statement.description.replacing("\(key) = ", with: "_\(key) = ")),
+            CodeBlockItemSyntax(stringLiteral: statement.description.replacing(propertyEqual(key), with: "_\(key) =")),
           ]
         }
       }
@@ -264,6 +265,48 @@ extension ThreadSafeInitializerMacro: BodyMacro {
     }
 
     return statements.compactMap(\.self)
+  }
+
+  /// Regex to match "self.key = "
+  private static func selfDotPropertyEqual(
+    _ propertyName: String,
+    isAtStart: Bool = false)
+    -> Regex<Regex<Substring>.RegexOutput>
+  {
+    if isAtStart {
+      Regex {
+        Anchor.startOfLine
+        "self."
+        propertyName
+        OneOrMore(.whitespace)
+        "="
+      }
+    } else {
+      Regex {
+        "self."
+        propertyName
+        OneOrMore(.whitespace)
+        "="
+      }
+    }
+  }
+
+  /// Regex to match "key = "
+  private static func propertyEqual(_ propertyName: String, isAtStart: Bool = false) -> Regex<Regex<Substring>.RegexOutput> {
+    if isAtStart {
+      Regex {
+        Anchor.startOfLine
+        propertyName
+        OneOrMore(.whitespace)
+        "="
+      }
+    } else {
+      Regex {
+        propertyName
+        OneOrMore(.whitespace)
+        "="
+      }
+    }
   }
 }
 

--- a/app/modules/macros/ThreadSafe/Tests/ThreadSafeMacroIntegrationTests.swift
+++ b/app/modules/macros/ThreadSafe/Tests/ThreadSafeMacroIntegrationTests.swift
@@ -340,4 +340,98 @@ final class ThreadSafeMacroIntegrationTests: XCTestCase {
         "ThreadSafeInitializer": ThreadSafeInitializerMacro.self,
       ])
   }
+
+  func testThreadSafeMacro_handleNonStandardSpacing() {
+    // Test that the Sendable macro adds the correct attributes and members
+    assertMacroExpansion(
+      """
+      @ThreadSafe
+      final class AIModelsManager {
+        init(localServer: LocalServer)
+        {
+          self.localServer = localServer
+
+          let llmModelByProvider = (try? Self.loadModels(fileManager: fileManager)) ?? [:]
+          self.llmModelByProvider = llmModelByProvider
+          let modelInfos = llmModelByProvider.values.flatMap(\\.self).reduce(into: [:]) { acc, model in
+            acc[model.modelInfo.id] = model.modelInfo
+          }
+          modelInfosByModelSlug  = modelInfos // double space here
+          mutableModels = .init(modelInfos.values.sorted(by: { $0.name < $1.name }))
+        }
+
+        var models: ReadonlyCurrentValueSubject<[AIModel], Never> {
+          mutableModels.readonly()
+        }
+
+        private let localServer: LocalServer
+
+        private var llmModelByProvider: [AIProvider: [AIProviderModel]]
+        private var modelInfosByModelSlug: [String: AIModel]
+
+        private let mutableModels: CurrentValueSubject<[AIModel], Never>
+      }
+      """,
+      expandedSource: """
+        final class AIModelsManager {
+          init(localServer: LocalServer){
+              var _llmModelByProvider: [AIProvider: [AIProviderModel]]
+              var _modelInfosByModelSlug: [String: AIModel]
+              self.localServer = localServer
+              let llmModelByProvider = (try? Self.loadModels(fileManager: fileManager)) ?? [:]
+              _llmModelByProvider = llmModelByProvider
+              let modelInfos = llmModelByProvider.values.flatMap(\\.self).reduce(into: [:]) { acc, model in
+                    acc[model.modelInfo.id] = model.modelInfo
+                  }
+              _modelInfosByModelSlug = modelInfos // double space here
+              self._internalState = Atomic<_InternalState>(_InternalState(llmModelByProvider: _llmModelByProvider, modelInfosByModelSlug: _modelInfosByModelSlug))
+              mutableModels = .init(modelInfos.values.sorted(by: {
+                          $0.name < $1.name
+                      }))
+          }
+
+          var models: ReadonlyCurrentValueSubject<[AIModel], Never> {
+            mutableModels.readonly()
+          }
+
+          private let localServer: LocalServer
+
+          private var llmModelByProvider: [AIProvider: [AIProviderModel]] {
+              get {
+                  _internalState.value.llmModelByProvider
+              }
+              set {
+                  _ = _internalState.set(\\.llmModelByProvider, to: newValue)
+              }
+          }
+          private var modelInfosByModelSlug: [String: AIModel] {
+              get {
+                  _internalState.value.modelInfosByModelSlug
+              }
+              set {
+                  _ = _internalState.set(\\.modelInfosByModelSlug, to: newValue)
+              }
+          }
+
+          private let mutableModels: CurrentValueSubject<[AIModel], Never>
+
+            private let _internalState: Atomic<_InternalState>
+
+            private struct _InternalState: Sendable {
+              var llmModelByProvider: [AIProvider: [AIProviderModel]]
+              var modelInfosByModelSlug: [String: AIModel]
+            }
+
+            @discardableResult
+              private func inLock<Result: Sendable>(_ mutation: @Sendable (inout _InternalState) -> Result) -> Result {
+                _internalState.mutate(mutation)
+              }
+        }
+        """,
+      macros: [
+        "ThreadSafe": ThreadSafeMacro.self,
+        "ThreadSafeProperty": ThreadSafePropertyMacro.self,
+        "ThreadSafeInitializer": ThreadSafeInitializerMacro.self,
+      ])
+  }
 }

--- a/app/modules/macros/ThreadSafe/Tests/ThreadSafeMacroIntegrationTests.swift
+++ b/app/modules/macros/ThreadSafe/Tests/ThreadSafeMacroIntegrationTests.swift
@@ -52,7 +52,6 @@ final class ThreadSafeMacroIntegrationTests: XCTestCase {
   }
 
   func testSimpleInitializers() {
-    // Test that the Sendable macro adds the correct attributes and members
     assertMacroExpansion(
       """
       @ThreadSafe


### PR DESCRIPTION
While spacing is typically standard (eg one space between variable and `=`), especially after linting, in some case `@ThreadSafe` was failing to compile due to unexpected spacing.

This was nnoying