### PR TITLE
Fix missing provider when one AI provider was removed

### DIFF
--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
@@ -67,7 +67,7 @@ public struct Settings: Sendable, Equatable {
     self.automaticallyCheckForUpdates = automaticallyCheckForUpdates
     self.automaticallyUpdateXcodeSettings = automaticallyUpdateXcodeSettings
     self.fileEditMode = fileEditMode
-    self.preferedProviders = preferedProviders
+    self.preferedProviders = preferedProviders.filter { llmProviderSettings[$0.value] != nil }
     self.llmProviderSettings = llmProviderSettings
     self.enabledModels = enabledModels
     self.reasoningModels = reasoningModels

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
@@ -127,7 +127,6 @@ public struct Settings: Sendable, Equatable {
   public var fileEditMode: FileEditMode
   // LLM settings
   public var preferedProviders: [AIModelID: AIProvider]
-  public var llmProviderSettings: [AIProvider: AIProviderSettings]
   public var reasoningModels: [AIModelID: LLMReasoningSetting]
 
   public var enabledModels: [AIModelID]
@@ -136,6 +135,14 @@ public struct Settings: Sendable, Equatable {
   public var keyboardShortcuts: KeyboardShortcuts
   public var userDefinedXcodeShortcuts: [UserDefinedXcodeShortcut]
   public var mcpServers: [String: MCPServerConfiguration]
+
+  public var llmProviderSettings: [AIProvider: AIProviderSettings] {
+    didSet {
+      // Ensure we don't keep prefered providers that are no longer configured.
+      preferedProviders = preferedProviders.filter { llmProviderSettings[$0.value] != nil }
+    }
+  }
+
 }
 
 // MARK: - Settings + Tool Preferences Helpers

--- a/app/modules/services/SettingsService/Sources/ExternalSettings.swift
+++ b/app/modules/services/SettingsService/Sources/ExternalSettings.swift
@@ -34,7 +34,7 @@ struct ExternalSettings: Sendable, Equatable {
     self.automaticallyCheckForUpdates = automaticallyCheckForUpdates
     self.automaticallyUpdateXcodeSettings = automaticallyUpdateXcodeSettings
     self.fileEditMode = fileEditMode
-    self.preferedProviders = preferedProviders
+    self.preferedProviders = preferedProviders.filter { llmProviderSettings[$0.value] != nil }
     self.llmProviderSettings = llmProviderSettings
     self.enabledModels = enabledModels
     self.reasoningModels = reasoningModels

--- a/app/modules/services/SettingsService/Tests/ExternalSettings+CodableTests.swift
+++ b/app/modules/services/SettingsService/Tests/ExternalSettings+CodableTests.swift
@@ -823,4 +823,26 @@ struct ExternalSettingsCodableTests {
     #expect(decodedSettings.llmProviderSettings.count == 1) // successfully decoded valid provider
     #expect(decodedSettings.llmProviderSettings[.anthropic]?.apiKey == "test-key")
   }
+
+  @Test("Filters preferred providers when llmProviderSettings is missing")
+  func testFiltersPreferedProvidersWhenProviderIsMissing() throws {
+    let settings = ExternalSettings(
+      preferedProviders: .init([
+        .claudeHaiku_3_5: .anthropic,
+        .gpt: .openAI,
+        .claudeSonnet: .anthropic,
+      ]),
+      llmProviderSettings: [
+        .anthropic: .init(
+          apiKey: "test-anthropic-api-key",
+          baseUrl: "https://api.anthropic.com",
+          executable: nil,
+          createdOrder: 1),
+      ])
+
+    #expect(settings.preferedProviders.count == 2)
+    #expect(settings.preferedProviders[.claudeHaiku_3_5] == .anthropic)
+    #expect(settings.preferedProviders[.claudeSonnet] == .anthropic)
+    #expect(settings.preferedProviders[.gpt] == nil)
+  }
 }


### PR DESCRIPTION
To reproduce the issue:
- Configure two AI providers
- Set some shared models to use provider A
- disable provider A

Those shared models are still configured to use the removed provider, and cannot be accessed.