### PR TITLE
Fix Gemini's baseUrl in local server's gemini.ts

### DIFF
--- a/local-server/src/server/providers/gemini.ts
+++ b/local-server/src/server/providers/gemini.ts
@@ -45,7 +45,7 @@ export class GeminiAIProvider implements AIProvider {
 		const baseUrl =
 			process.env["GEMINI_LOCAL_SERVER_PROXY"] ??
 			params.baseUrl ??
-			"https://generativelanguage.googleapis.com/v1beta/"
+			"https://generativelanguage.googleapis.com/v1beta"
 		const allModels: ModelBaseInfo[] = []
 		let nextPageToken: string | undefined = undefined
 


### PR DESCRIPTION
The trailing slash eventually causes HTTP 404 error (see below)

```
[Error] Failed to fetch models for provider gemini: The operation couldn’t be completed. (LocalServerServiceInterface.APIError error 1.)

debugDescription: LocalServerServiceInterface.APIError(statusCode: 500, localizedDescription: "HTTP status code 404. Data: {\"type\":\"error\",\"success\":false,\"statusCode\":404,\"message\":\"Not Found\",\"stack\":\"
Error: Failed to fetch models at https://generativelanguage.googleapis.com/v1beta//models for provider gemini with error message: Not Found\\n    at Bv.listModels (/Users/xxxxxx/Library/src/server/providers/gemini.ts:68:23)
```