### PR TITLE
handle skipped jobs in 🚀 merge

### DIFF
--- a/.github/workflows/rocket-merge.yml
+++ b/.github/workflows/rocket-merge.yml
@@ -175,10 +175,10 @@ jobs:
               const hasCheckRuns = checks.data.check_runs.length > 0;
 
               const allChecksComplete = checks.data.check_runs.every(check =>
-                check.status === 'completed'
+                check.status === 'completed' || check.conclusion === 'skipped'
               );
               const allChecksSuccess = checks.data.check_runs.every(check =>
-                check.conclusion === 'success' || check.conclusion === 'skipped'
+                check.conclusion === 'success' || check.conclusion === 'skipped' || check.conclusion === 'neutral'
               );
 
               console.log(`Status state: ${statusState}, Has statuses: ${hasStatuses}, Has check runs: ${hasCheckRuns}`);


### PR DESCRIPTION
For instance this case:
<img width="917" height="507" alt="Screenshot 2025-10-15 at 10 48 31 PM" src="https://github.com/user-attachments/assets/b8a2e649-66f3-4867-b078-2cab34243204" />
