### PR TITLE
Fix tool mapping for Claude Code's grep when using ACP

### DIFF
--- a/local-server/src/server/endpoints/sendMessage/acp/clients/claudeCode/helper.ts
+++ b/local-server/src/server/endpoints/sendMessage/acp/clients/claudeCode/helper.ts
@@ -58,7 +58,7 @@ const toolNameMapping: { [k: string]: string } = {
 	Write: "edit_file",
 	Bash: "bash",
 	LS: "list_files",
-	Grep: "search",
+	Grep: "search_files",
 }
 
 export async function* withParsedToolCalls(


### PR DESCRIPTION
Grep should map to `search_files`, not `search` which is not the name of one of the tools available in the app