### PR TITLE
Setup the repo when running commands, if needed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,6 +127,8 @@ jobs:
       with:
         path: local-server/node_modules
         key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+    - name: Install dependencies
+      run: cd local-server && yarn install && yarn build && yarn copy-to-app
     - name: Load SPM cache
       uses: actions/cache@v4
       with:
@@ -234,6 +236,8 @@ jobs:
       with:
         path: local-server/node_modules
         key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+    - name: Install dependencies
+      run: cd local-server && yarn install
     - name: Run tests
       run: ./cmd.sh test:ts
 
@@ -280,6 +284,8 @@ jobs:
       with:
         path: local-server/node_modules
         key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+    - name: Install dependencies
+      run: cd local-server && yarn install
     - name: Run linter
       run: ./cmd.sh lint:ts
     - name: Verify that `cmd lint:ts` did not change outputs (if it did, please re-run it and re-commit!)


### PR DESCRIPTION
This will help spawning worktrees and have them ready to go when needed