### PR TITLE
Fix zip changes

### DIFF
--- a/local-server/tools/copy-to-app.ts
+++ b/local-server/tools/copy-to-app.ts
@@ -65,7 +65,7 @@ const copyIconsToApp = async () => {
 	await new Promise<void>((resolve, reject) => {
 		const tarProcess = spawn("sh", [
 			"-c",
-			`cd ${tmpDir} && find . -type f | sort | tar -cf - -T - --uid 0 --gid 0 --uname root --gname root --no-mac-metadata --no-xattrs | gzip -n > ${archivePath}`,
+			`cd ${tmpDir} && LC_ALL=C find . -type f | LC_ALL=C sort | tar -cf - -T - --uid 0 --gid 0 --uname root --gname root --no-mac-metadata --no-xattrs | gzip -n > ${archivePath}`,
 		])
 		tarProcess.on("error", reject)
 		tarProcess.on("close", (code) => {


### PR DESCRIPTION
Fix the zipped assets changing between local and CI, due to different sorting behavior. When comparing two different archives:

Root cause:
The two tar.gz archives had files in different orders due to locale-specific sorting behavior. When I compared the archives:

- Original: auto.svg → auto_light.svg
- Changed: auto_light.svg → auto.svg

The sort command's behavior depends on the LC_COLLATE locale setting:
- In UTF-8 locales (like en_US.UTF-8), underscore sorts before dot
- In C locale, dot sorts before underscore (by ASCII value)