### PR TITLE
remove cache key suffix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,10 @@ jobs:
     uses: ./.github/workflows/reusable-build-release-app.yml
     with:
       save_cache: true
-      cache_key_suffix: main
     secrets: inherit
 
   test_swift_app:
     uses: ./.github/workflows/reusable-test-swift-app.yml
     with:
       save_cache: true
-      cache_key_suffix: main
     secrets: inherit

--- a/.github/workflows/reusable-build-release-app.yml
+++ b/.github/workflows/reusable-build-release-app.yml
@@ -7,10 +7,6 @@ on:
         description: "Whether to save cache (true) or only load (false)"
         required: true
         type: boolean
-      cache_key_suffix:
-        description: "Suffix for cache keys (e.g., main). If not provided, uses hash-based keys."
-        required: false
-        type: string
 
 jobs:
   build_release_app:
@@ -36,9 +32,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: local-server/node_modules
-          key: ${{ runner.os }}_npm_modules_${{ inputs.cache_key_suffix || hashFiles('local-server/yarn.lock') }}
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}_npm_modules_main
             ${{ runner.os }}_npm_modules_
       - name: Install node dependencies
         run: cd local-server && yarn install && yarn build && yarn copy-to-app
@@ -54,17 +49,15 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
-          key: ${{ runner.os }}_spm_packages_${{ inputs.cache_key_suffix || hashFiles('app/modules/Package.resolved') }}
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}_spm_packages_main
             ${{ runner.os }}_spm_packages_
       - name: Restore release build cache
         uses: actions/cache/restore@v4
         with:
           path: app/build/derived_data
-          key: ${{ runner.os }}_release_build_${{ inputs.cache_key_suffix || hashFiles('app/**') }}
+          key: ${{ runner.os }}_release_build_${{ hashFiles('app/**') }}
           restore-keys: |
-            ${{ runner.os }}_release_build_main
             ${{ runner.os }}_release_build_
       - name: Install fastlane dependencies
         run: |
@@ -93,7 +86,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: app/build/derived_data
-          key: ${{ runner.os }}_release_build_${{ inputs.cache_key_suffix || hashFiles('app/**') }}
+          key: ${{ runner.os }}_release_build_${{ hashFiles('app/**') }}
       - name: Save SPM packages cache
         if: ${{ inputs.save_cache }}
         uses: actions/cache/save@v4
@@ -101,10 +94,10 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
-          key: ${{ runner.os }}_spm_packages_${{ inputs.cache_key_suffix || hashFiles('app/modules/Package.resolved') }}
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
       - name: Save npm cache
         if: ${{ inputs.save_cache }}
         uses: actions/cache/save@v4
         with:
           path: local-server/node_modules
-          key: ${{ runner.os }}_npm_modules_${{ inputs.cache_key_suffix || hashFiles('local-server/yarn.lock') }}
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}

--- a/.github/workflows/reusable-test-swift-app.yml
+++ b/.github/workflows/reusable-test-swift-app.yml
@@ -7,10 +7,6 @@ on:
         description: "Whether to save cache (true) or only load (false)"
         required: true
         type: boolean
-      cache_key_suffix:
-        description: "Suffix for cache keys (e.g., main). If not provided, uses hash-based keys."
-        required: false
-        type: string
 
 jobs:
   test_swift_app:
@@ -36,9 +32,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: local-server/node_modules
-          key: ${{ runner.os }}_npm_modules_${{ inputs.cache_key_suffix || hashFiles('local-server/yarn.lock') }}
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}_npm_modules_main
             ${{ runner.os }}_npm_modules_
       - name: Install dependencies
         run: cd local-server && yarn install && yarn build && yarn copy-to-app
@@ -47,17 +42,15 @@ jobs:
         with:
           path: ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
-          key: ${{ runner.os }}_spm_packages_${{ inputs.cache_key_suffix || hashFiles('app/modules/Package.resolved') }}
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}_spm_packages_main
             ${{ runner.os }}_spm_packages_
       - name: Restore modules build cache
         uses: actions/cache/restore@v4
         with:
           path: app/modules/.build
-          key: ${{ runner.os }}_modules_build_${{ inputs.cache_key_suffix || hashFiles('app/modules/**') }}
+          key: ${{ runner.os }}_modules_build_${{ hashFiles('app/modules/**') }}
           restore-keys: |
-            ${{ runner.os }}_modules_build_main
             ${{ runner.os }}_modules_build_
       - name: Run app module tests
         run: ./cmd.sh test:swift
@@ -66,17 +59,17 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: app/modules/.build
-          key: ${{ runner.os }}_modules_build_${{ inputs.cache_key_suffix || hashFiles('app/modules/**') }}
+          key: ${{ runner.os }}_modules_build_${{ hashFiles('app/modules/**') }}
       - name: Save SPM cache
         if: ${{ inputs.save_cache }}
         uses: actions/cache/save@v4
         with:
           path: ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
-          key: ${{ runner.os }}_spm_packages_${{ inputs.cache_key_suffix || hashFiles('app/modules/Package.resolved') }}
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
       - name: Save npm cache
         if: ${{ inputs.save_cache }}
         uses: actions/cache/save@v4
         with:
           path: local-server/node_modules
-          key: ${{ runner.os }}_npm_modules_${{ inputs.cache_key_suffix || hashFiles('local-server/yarn.lock') }}
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}


### PR DESCRIPTION
Update some changes from https://github.com/getcmd-dev/cmd/pull/217

It turns out that the github action `action/save` doesn't allow to update an existing cache entry:

https://github.com/getcmd-dev/cmd/actions/runs/19007170834

<img width="889" height="113" alt="Screenshot 2025-11-01 at 9 36 43 PM" src="https://github.com/user-attachments/assets/7e9eb080-cf29-412b-8e4e-e9fb0e9aafa9" />
