### PR TITLE
Fix ReadonlyCurrentValueSubject not updating current value

### DIFF
--- a/app/modules/App/Sources/Dependencies.swift
+++ b/app/modules/App/Sources/Dependencies.swift
@@ -57,7 +57,7 @@ extension AppEventHandlerRegistryDependencyKey: DependencyKey {
 // MARK: - AppsActivationStateDependencyKey + DependencyKey
 
 extension AppsActivationStateDependencyKey: DependencyKey {
-  public static var liveValue: ReadonlyCurrentValueSubject<AppsActivationState, Never> {
+  public static var liveValue: ReadonlyCurrentValueSubject<AppsActivationState> {
     AppScope.shared.appsActivationState
   }
 }

--- a/app/modules/App/Sources/XcodeKeyboardShortcuts.swift
+++ b/app/modules/App/Sources/XcodeKeyboardShortcuts.swift
@@ -19,7 +19,7 @@ import XcodeObserverServiceInterface
 @ThreadSafe
 final class XcodeKeyboardShortcutsManager: @unchecked Sendable {
 
-  init(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never>) {
+  init(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState>) {
     registerActions()
 
     observeXcodeState(appsActivationState: appsActivationState)
@@ -35,7 +35,7 @@ final class XcodeKeyboardShortcutsManager: @unchecked Sendable {
   @Dependency(\.settingsService) private var settingsService
 
   /// This can be moved to the initializer once https://github.com/swiftlang/swift/issues/80050 is fixed.
-  private func observeXcodeState(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never>) {
+  private func observeXcodeState(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState>) {
     let cancellable = appsActivationState
       .sink { @Sendable [weak self] appsActivationState in
         guard let self else { return }

--- a/app/modules/foundations/ConcurrencyFoundation/Sources/ObservableObjectBox.swift
+++ b/app/modules/foundations/ConcurrencyFoundation/Sources/ObservableObjectBox.swift
@@ -11,7 +11,7 @@ import os
 /// Updates are done in the main thread, asynchronously from the upstream source if this one is not running on the main thread, synchronously otherwise.
 public final class ObservableObjectBox<Value: Sendable>: ObservableObject, @unchecked Sendable {
   @MainActor
-  public init(from value: ReadonlyCurrentValueSubject<Value, Never>) {
+  public init(from value: ReadonlyCurrentValueSubject<Value>) {
     wrappedValue = value.currentValue
 
     cancellable = value.sink { @Sendable [weak self] newValue in

--- a/app/modules/foundations/ConcurrencyFoundation/Sources/ReadonlyCurrentValueSubject.swift
+++ b/app/modules/foundations/ConcurrencyFoundation/Sources/ReadonlyCurrentValueSubject.swift
@@ -9,16 +9,21 @@ import os
 
 /// `ReadonlyCurrentValueSubject` is a readonly version of `CurrentValueSubject`.
 /// It can be used to represent a value that can be observed but not modified directly.
-public final class ReadonlyCurrentValueSubject<Output: Sendable, Failure: Error>: Publisher, Sendable {
-
-  public init(_ value: Output, publisher: AnyPublisher<Output, Failure>) {
+public final class ReadonlyCurrentValueSubject<Output: Sendable>: Publisher, Sendable {
+  public init(_ value: Output, publisher: AnyPublisher<Output, Never>) {
     self.value = Atomic(value)
     self.publisher = publisher
+    let cancellable = publisher.sink { [weak self] newValue in
+      self?.value.set(to: newValue)
+    }
+    subscription.set(to: cancellable)
   }
 
-  public convenience init(_ value: CurrentValueSubject<Output, Failure>) {
+  public convenience init(_ value: CurrentValueSubject<Output, Never>) {
     self.init(value.value, publisher: value.eraseToAnyPublisher())
   }
+
+  public typealias Failure = Never
 
   public var currentValue: Output {
     value.value
@@ -28,23 +33,24 @@ public final class ReadonlyCurrentValueSubject<Output: Sendable, Failure: Error>
     .init(value, publisher: CurrentValueSubject(value).eraseToAnyPublisher())
   }
 
-  public func receive<S>(subscriber: S) where S: Subscriber, S.Failure == Failure, S.Input == Output {
+  public func receive<S>(subscriber: S) where S: Subscriber, S.Failure == Never, S.Input == Output {
     publisher.receive(subscriber: subscriber)
   }
 
   private let value: Atomic<Output>
-  private let publisher: AnyPublisher<Output, Failure>
+  private let subscription = Atomic(nil as AnyCancellable?)
+  private let publisher: AnyPublisher<Output, Never>
 
 }
 
-extension CurrentValueSubject where Output: Sendable {
-  public func readonly() -> ReadonlyCurrentValueSubject<Output, Failure> {
+extension CurrentValueSubject where Output: Sendable, Failure == Never {
+  public func readonly() -> ReadonlyCurrentValueSubject<Output> {
     ReadonlyCurrentValueSubject(value, publisher: eraseToAnyPublisher())
   }
 }
 
-extension CurrentValueSubject where Output: Sendable & Equatable {
-  public func readonly(removingDuplicate: Bool) -> ReadonlyCurrentValueSubject<Output, Failure> {
+extension CurrentValueSubject where Output: Sendable & Equatable, Failure == Never {
+  public func readonly(removingDuplicate: Bool) -> ReadonlyCurrentValueSubject<Output> {
     if removingDuplicate {
       ReadonlyCurrentValueSubject(value, publisher: removeDuplicates().eraseToAnyPublisher())
     } else {

--- a/app/modules/serviceInterfaces/AppUpdateServiceInterface/Sources/AppUpdateService+Mock.swift
+++ b/app/modules/serviceInterfaces/AppUpdateServiceInterface/Sources/AppUpdateService+Mock.swift
@@ -21,7 +21,7 @@ public final class MockAppUpdateService: AppUpdateService {
   public var onIgnoreUpdate: (@Sendable (AppUpdateInfo?) -> Void)?
   public var onIsUpdateIgnored: (@Sendable (AppUpdateInfo?) -> Bool)?
 
-  public var hasUpdateAvailable: ReadonlyCurrentValueSubject<AppUpdateResult, Never> {
+  public var hasUpdateAvailable: ReadonlyCurrentValueSubject<AppUpdateResult> {
     _hasUpdateAvailable.readonly()
   }
 

--- a/app/modules/serviceInterfaces/AppUpdateServiceInterface/Sources/AppUpdateService.swift
+++ b/app/modules/serviceInterfaces/AppUpdateServiceInterface/Sources/AppUpdateService.swift
@@ -37,7 +37,7 @@ public protocol AppUpdateService: Sendable {
   /// Trigger a manual check for updates.
   func checkForUpdates() /// Whether there an app update has been installed.
     async
-  var hasUpdateAvailable: ReadonlyCurrentValueSubject<AppUpdateResult, Never> { get }
+  var hasUpdateAvailable: ReadonlyCurrentValueSubject<AppUpdateResult> { get }
   /// Ignore the current update and don't show info about it again (the update might still be installed at the next launch)
   func ignore(update: AppUpdateInfo?)
   /// Return whether a given update is ignored.

--- a/app/modules/serviceInterfaces/GithubCopilotServiceInterface/Sources/GithubCopilotService+Mock.swift
+++ b/app/modules/serviceInterfaces/GithubCopilotServiceInterface/Sources/GithubCopilotService+Mock.swift
@@ -29,11 +29,11 @@ public final class MockGithubCopilotService: GithubCopilotService {
   public var onConfirmSignIn: (@Sendable (String) async throws -> Void)?
   public var onSignOut: (@Sendable () async throws -> Void)?
 
-  public var loginStatus: ReadonlyCurrentValueSubject<LoginStatus, Never> {
+  public var loginStatus: ReadonlyCurrentValueSubject<LoginStatus> {
     _loginStatus.readonly()
   }
 
-  public var isLSPServerInstalled: ReadonlyCurrentValueSubject<Bool, Never> {
+  public var isLSPServerInstalled: ReadonlyCurrentValueSubject<Bool> {
     _isLSPServerInstalled.readonly()
   }
 

--- a/app/modules/serviceInterfaces/GithubCopilotServiceInterface/Sources/GithubCopilotService.swift
+++ b/app/modules/serviceInterfaces/GithubCopilotServiceInterface/Sources/GithubCopilotService.swift
@@ -17,9 +17,9 @@ public protocol GithubCopilotService: CodeCompletionProvider {
   /// Sign out the current user
   func signOut() async throws
   /// Whether the LSP server is installed
-  var isLSPServerInstalled: ReadonlyCurrentValueSubject<Bool, Never> { get }
+  var isLSPServerInstalled: ReadonlyCurrentValueSubject<Bool> { get }
   /// The current login status
-  var loginStatus: ReadonlyCurrentValueSubject<LoginStatus, Never> { get }
+  var loginStatus: ReadonlyCurrentValueSubject<LoginStatus> { get }
 }
 
 // MARK: - LoginStatus

--- a/app/modules/serviceInterfaces/LLMServiceInterface/Sources/LLMService+Mock.swift
+++ b/app/modules/serviceInterfaces/LLMServiceInterface/Sources/LLMService+Mock.swift
@@ -46,26 +46,26 @@ public final class MockLLMService: LLMService {
 
   public var onLowTierModel: (@Sendable () -> AIProviderModel?)?
 
-  public var availableModels: ReadonlyCurrentValueSubject<[AIModel], Never> { _availableModels.readonly() }
+  public var availableModels: ReadonlyCurrentValueSubject<[AIModel]> { _availableModels.readonly() }
 
-  public var activeModels: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  public var activeModels: ReadonlyCurrentValueSubject<[AIModel]> {
     _activeModels.readonly()
   }
 
-  public func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?, Never> {
+  public func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?> {
     .just(onProviderForModel?(model))
   }
 
-  public func getModelInfo(by modelInfoId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?, Never> {
+  public func getModelInfo(by modelInfoId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?> {
     .just(onGetModelInfo?(modelInfoId))
   }
 
-  public func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?, Never> {
+  public func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?> {
     .just(onGetModel?(providerModelId))
   }
 
   public func modelsAvailable(for provider: AIProvider)
-    -> ReadonlyCurrentValueSubject<[AIProviderModel], Never>
+    -> ReadonlyCurrentValueSubject<[AIProviderModel]>
   {
     .just(onListModelsAvailable?(provider) ?? [])
   }

--- a/app/modules/serviceInterfaces/LLMServiceInterface/Sources/LLMService.swift
+++ b/app/modules/serviceInterfaces/LLMServiceInterface/Sources/LLMService.swift
@@ -58,32 +58,32 @@ public protocol LLMService: Sendable {
 
   /// All the models available.
   /// Note: those models might not have been enabled by the user.
-  var availableModels: ReadonlyCurrentValueSubject<[AIModel], Never> { get }
+  var availableModels: ReadonlyCurrentValueSubject<[AIModel]> { get }
 
   /// Returns the list of available models from the specified provider.
   /// Note: those models might not have been enabled by the user.
   ///
   /// - Parameter provider: The LLM provider to get models for.
   /// - Returns: An array of available models for the provider. The value will be updated when the value changes.
-  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel], Never>
+  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel]>
 
   /// Retrieves a model by its provider-specific model identifier.
   ///
   /// - Parameter providerModelId: The provider-specific identifier for the model.
   /// - Returns: The model if found, otherwise nil. The value will be updated when the value changes.
-  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?, Never>
+  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?>
 
   /// Retrieves model information by its model info identifier.
   ///
   /// - Parameter modelInfoId: The unique identifier for the model info.
   /// - Returns: The model information if found, otherwise nil. The value will be updated when the value changes.
-  func getModelInfo(by modelInfoId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?, Never>
+  func getModelInfo(by modelInfoId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?>
 
   /// Determines which provider is associated with the given model.
   ///
   /// - Parameter model: The model information to find the provider for.
   /// - Returns: The provider that owns the model, or nil if not found. The value will be updated when the value changes.
-  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?, Never>
+  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?>
 
   /// Refetches and returns the list of available models for the specified provider with new settings.
   ///
@@ -98,7 +98,7 @@ public protocol LLMService: Sendable {
     async throws -> [AIProviderModel]
 
   /// The models that have a provider configured and are enabled (ie the models that the user is able to use given their current configuration).
-  var activeModels: ReadonlyCurrentValueSubject<[AIModel], Never> { get }
+  var activeModels: ReadonlyCurrentValueSubject<[AIModel]> { get }
 
   /// Returns the low tier model from configured providers with the cheapest input cost.
   /// Low tier models are suitable for simple queries that favor speed & low cost over accuracy.

--- a/app/modules/serviceInterfaces/MCPServiceInterface/Sources/MCPService+Mock.swift
+++ b/app/modules/serviceInterfaces/MCPServiceInterface/Sources/MCPService+Mock.swift
@@ -24,7 +24,7 @@ public final class MockMCPService: MCPService {
     MockMCPServerConnection()
   }
 
-  public var servers: ReadonlyCurrentValueSubject<[MCPServerConnectionStatus], Never> {
+  public var servers: ReadonlyCurrentValueSubject<[MCPServerConnectionStatus]> {
     _servers.readonly()
   }
 
@@ -42,7 +42,7 @@ public final class MockMCPService: MCPService {
 }
 
 public struct MockMCPServerConnection: MCPServerConnection {
-  public var connectionStatus: ReadonlyCurrentValueSubject<MCPConnectionStatus, Never> {
+  public var connectionStatus: ReadonlyCurrentValueSubject<MCPConnectionStatus> {
     connectionStatusPublisher.readonly()
   }
 

--- a/app/modules/serviceInterfaces/MCPServiceInterface/Sources/MCPService.swift
+++ b/app/modules/serviceInterfaces/MCPServiceInterface/Sources/MCPService.swift
@@ -28,7 +28,7 @@ public protocol MCPService: Sendable {
   /// - `.loading`: Server connection is being established
   /// - `.success`: Server is connected and operational
   /// - `.failure`: Server connection failed with an error
-  var servers: ReadonlyCurrentValueSubject<[MCPServerConnectionStatus], Never> { get }
+  var servers: ReadonlyCurrentValueSubject<[MCPServerConnectionStatus]> { get }
 
   /// Establishes a connection to the specified MCP server.
   ///
@@ -107,7 +107,7 @@ public protocol MCPServerConnection: Sendable {
     /// Emits `.connected` when the server is operational and `.disconnected` when the connection is lost.
     async
 
-  var connectionStatus: ReadonlyCurrentValueSubject<MCPConnectionStatus, Never> { get }
+  var connectionStatus: ReadonlyCurrentValueSubject<MCPConnectionStatus> { get }
 }
 
 // MARK: - ServerInfo

--- a/app/modules/serviceInterfaces/PermissionsServiceInterface/Sources/PermissionService.swift
+++ b/app/modules/serviceInterfaces/PermissionsServiceInterface/Sources/PermissionService.swift
@@ -18,7 +18,7 @@ public protocol PermissionsService: Sendable {
   func request(permission: Permission)
 
   /// Check if the permission is granted. The publisher will be updated as the permissions status changes.
-  func status(for permission: Permission) -> ReadonlyCurrentValueSubject<Bool?, Never>
+  func status(for permission: Permission) -> ReadonlyCurrentValueSubject<Bool?>
 }
 
 // MARK: - PermissionsServiceProviding

--- a/app/modules/serviceInterfaces/PermissionsServiceInterface/Sources/PermissionsService+Mock.swift
+++ b/app/modules/serviceInterfaces/PermissionsServiceInterface/Sources/PermissionsService+Mock.swift
@@ -32,7 +32,7 @@ public final class MockPermissionsService: PermissionsService {
     }
   }
 
-  public func status(for permission: Permission) -> ReadonlyCurrentValueSubject<Bool?, Never> {
+  public func status(for permission: Permission) -> ReadonlyCurrentValueSubject<Bool?> {
     switch permission {
     case .accessibility:
       isAccessibilityPermissionGranted.readonly(removingDuplicate: true)

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService+Mock.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService+Mock.swift
@@ -22,7 +22,7 @@ public final class MockSettingsService: SettingsService {
     settings.value[keyPath: keypath]
   }
 
-  public func liveValue<T: Equatable>(for keypath: KeyPath<Settings, T>) -> ReadonlyCurrentValueSubject<T, Never> {
+  public func liveValue<T: Equatable>(for keypath: KeyPath<Settings, T>) -> ReadonlyCurrentValueSubject<T> {
     ReadonlyCurrentValueSubject(
       settings.value[keyPath: keypath],
       publisher: settings.map { $0[keyPath: keypath] }.removeDuplicates().eraseToAnyPublisher())
@@ -32,7 +32,7 @@ public final class MockSettingsService: SettingsService {
     settings.value
   }
 
-  public func liveValues() -> ReadonlyCurrentValueSubject<Settings, Never> {
+  public func liveValues() -> ReadonlyCurrentValueSubject<Settings> {
     ReadonlyCurrentValueSubject(settings)
   }
 

--- a/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
+++ b/app/modules/serviceInterfaces/SettingsServiceInterface/Sources/SettingsService.swift
@@ -328,13 +328,13 @@ public protocol SettingsService: Sendable {
   /// Get the current value of a setting.
   func value<T: Equatable>(for keypath: KeyPath<Settings, T>) -> T
   /// Get the current value of a setting as a live value.
-  func liveValue<T: Equatable>(for keypath: KeyPath<Settings, T>) -> ReadonlyCurrentValueSubject<T, Never>
+  func liveValue<T: Equatable>(for keypath: KeyPath<Settings, T>) -> ReadonlyCurrentValueSubject<T>
 
   /// Get all settings.
   func values() -> Settings
 
   /// Get all settings as a live value.
-  func liveValues() -> ReadonlyCurrentValueSubject<Settings, Never>
+  func liveValues() -> ReadonlyCurrentValueSubject<Settings>
 
   /// Update the value of a setting
   func update<T: Equatable>(setting: WritableKeyPath<Settings, T>, to value: T)

--- a/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/AppsActivationState+Dependency.swift
+++ b/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/AppsActivationState+Dependency.swift
@@ -8,10 +8,10 @@ import Dependencies
 
 public final class AppsActivationStateDependencyKey: TestDependencyKey {
   #if DEBUG
-  public static let testValue: ReadonlyCurrentValueSubject<AppsActivationState, Never> = AppsActivationState.mockPublisher()
+  public static let testValue: ReadonlyCurrentValueSubject<AppsActivationState> = AppsActivationState.mockPublisher()
   #else
   /// This is not read outside of DEBUG
-  public static let testValue: ReadonlyCurrentValueSubject<AppsActivationState, Never> = () as! ReadonlyCurrentValueSubject<
+  public static let testValue: ReadonlyCurrentValueSubject<AppsActivationState> = () as! ReadonlyCurrentValueSubject<
     AppsActivationState,
     Never,
   >
@@ -19,7 +19,7 @@ public final class AppsActivationStateDependencyKey: TestDependencyKey {
 }
 
 extension DependencyValues {
-  public var appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never> {
+  public var appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState> {
     get { self[AppsActivationStateDependencyKey.self] }
     set { self[AppsActivationStateDependencyKey.self] = newValue }
   }

--- a/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/AppsActivationState+Mock.swift
+++ b/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/AppsActivationState+Mock.swift
@@ -5,7 +5,7 @@ import Combine
 import ConcurrencyFoundation
 
 extension AppsActivationState {
-  public static func mockPublisher() -> ReadonlyCurrentValueSubject<AppsActivationState, Never> {
+  public static func mockPublisher() -> ReadonlyCurrentValueSubject<AppsActivationState> {
     .init(.inactive, publisher: Just(.inactive).eraseToAnyPublisher())
   }
 }

--- a/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/AppsActivationState.swift
+++ b/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/AppsActivationState.swift
@@ -38,5 +38,5 @@ extension AppsActivationState {
 // MARK: - AppsActivationStateProviding
 
 public protocol AppsActivationStateProviding {
-  var appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never> { get }
+  var appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState> { get }
 }

--- a/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/XcodeObserver+Mock.swift
+++ b/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/XcodeObserver+Mock.swift
@@ -45,7 +45,7 @@ public final class MockXcodeObserver: XcodeObserver {
     Just(AXNotification.applicationActivated).eraseToAnyPublisher()
   }
 
-  public var statePublisher: ReadonlyCurrentValueSubject<AXState<XcodeState>, Never> {
+  public var statePublisher: ReadonlyCurrentValueSubject<AXState<XcodeState>> {
     mutableStatePublisher.readonly()
   }
 

--- a/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/XcodeObserver.swift
+++ b/app/modules/serviceInterfaces/XcodeObserverServiceInterface/Sources/XcodeObserver.swift
@@ -10,7 +10,7 @@ import LoggingServiceInterface
 // MARK: - XcodeObserver
 
 public protocol XcodeObserver: Sendable {
-  var statePublisher: ReadonlyCurrentValueSubject<AXState<XcodeState>, Never> { get }
+  var statePublisher: ReadonlyCurrentValueSubject<AXState<XcodeState>> { get }
   var axNotifications: AnyPublisher<AXNotification, Never> { get }
   /// Return the content of the file.
   /// The read strategy (IDE version / from disk) should match the write strategy defined in `fileEditMode`.

--- a/app/modules/services/AppUpdateService/Sources/DefaultAppUpdateService.swift
+++ b/app/modules/services/AppUpdateService/Sources/DefaultAppUpdateService.swift
@@ -26,7 +26,7 @@ final class DefaultAppUpdateService: AppUpdateService {
     monitorSettingChanges()
   }
 
-  var hasUpdateAvailable: ConcurrencyFoundation.ReadonlyCurrentValueSubject<AppUpdateResult, Never> {
+  var hasUpdateAvailable: ConcurrencyFoundation.ReadonlyCurrentValueSubject<AppUpdateResult> {
     _hasUpdateAvailable.readonly()
   }
 

--- a/app/modules/services/GithubCopilotService/Sources/DefaultGithubCopilotService.swift
+++ b/app/modules/services/GithubCopilotService/Sources/DefaultGithubCopilotService.swift
@@ -55,7 +55,7 @@ final class DefaultGithubCopilotService: GithubCopilotService {
   let authServer: Future<GithubCopilotServer, Error>
   let setAuthServer: @Sendable (Result<GithubCopilotServer, Error>) -> Void
 
-  var isLSPServerInstalled: ReadonlyCurrentValueSubject<Bool, Never> {
+  var isLSPServerInstalled: ReadonlyCurrentValueSubject<Bool> {
     _isLSPServerInstalled.readonly()
   }
 

--- a/app/modules/services/GithubCopilotService/Sources/GithubCopilotService+Auth.swift
+++ b/app/modules/services/GithubCopilotService/Sources/GithubCopilotService+Auth.swift
@@ -11,7 +11,7 @@ import LoggingServiceInterface
 
 extension DefaultGithubCopilotService {
 
-  var loginStatus: ReadonlyCurrentValueSubject<LoginStatus, Never> {
+  var loginStatus: ReadonlyCurrentValueSubject<LoginStatus> {
     _loginStatus.readonly()
   }
 

--- a/app/modules/services/KeyboardShortcutService/Sources/DefaultKeyboardShortcutService.swift
+++ b/app/modules/services/KeyboardShortcutService/Sources/DefaultKeyboardShortcutService.swift
@@ -16,7 +16,7 @@ import XcodeObserverServiceInterface
 
 @ThreadSafe
 final class DefaultKeyboardShortcutService: KeyboardShortcutService, @unchecked Sendable {
-  init(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never>) {
+  init(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState>) {
     observeActivationState(appsActivationState: appsActivationState)
   }
 
@@ -101,7 +101,7 @@ final class DefaultKeyboardShortcutService: KeyboardShortcutService, @unchecked 
   private var enabledShortcutNames = Set<String>()
 
   /// This can be moved to the initializer once https://github.com/swiftlang/swift/issues/80050 is fixed.
-  private func observeActivationState(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never>) {
+  private func observeActivationState(appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState>) {
     let cancellable = appsActivationState
       .sink { @Sendable [weak self] appsActivationState in
         guard let self else { return }

--- a/app/modules/services/LLMService/Sources/LLMModelManager.swift
+++ b/app/modules/services/LLMService/Sources/LLMModelManager.swift
@@ -35,22 +35,22 @@ protocol AIModelsManagerProtocol: Sendable {
   // - Return a higher level object that could be queried for each value of interest.
   // No solution worked well with targetted invalidation when only one model / one provider changes.
 
-  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?, Never>
+  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?>
 
-  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel], Never>
+  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel]>
 
-  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?, Never>
+  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?>
 
-  func getModelInfo(by modelId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?, Never>
+  func getModelInfo(by modelId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?>
 
-  var availableModels: ReadonlyCurrentValueSubject<[AIModel], Never> { get }
+  var availableModels: ReadonlyCurrentValueSubject<[AIModel]> { get }
 
   func refetchModelsAvailable(
     for provider: AIProvider,
     newSettings: Settings.AIProviderSettings)
     async throws -> [AIProviderModel]
 
-  var activeModels: ReadonlyCurrentValueSubject<[AIModel], Never> { get }
+  var activeModels: ReadonlyCurrentValueSubject<[AIModel]> { get }
 }
 
 // MARK: - AIModelsManager
@@ -99,23 +99,23 @@ final class AIModelsManager: AIModelsManagerProtocol {
     observerChangesToSettings()
   }
 
-  var availableModels: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  var availableModels: ReadonlyCurrentValueSubject<[AIModel]> {
     _availableModels.readonly()
   }
 
-  var models: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  var models: ReadonlyCurrentValueSubject<[AIModel]> {
     mutableModels.readonly()
   }
 
-  var activeModels: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  var activeModels: ReadonlyCurrentValueSubject<[AIModel]> {
     _activeModels.readonly()
   }
 
-  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?, Never> {
+  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?> {
     let preferredProvider = settingsService.liveValue(for: \.preferedProviders)
     let providersAvailableForModel = providerModelsByModelId.subscribeToValue(for: model.id)
 
-    return ReadonlyCurrentValueSubject<AIProvider?, Never>(
+    return ReadonlyCurrentValueSubject<AIProvider?>(
       preferredProvider.currentValue[model.id] ?? providersAvailableForModel.currentValue?.first?.provider,
       publisher: preferredProvider
         .map { $0[model.id] }
@@ -127,7 +127,7 @@ final class AIModelsManager: AIModelsManagerProtocol {
         .eraseToAnyPublisher())
   }
 
-  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel], Never> {
+  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel]> {
     let publisher = llmModelByProvider.subscribeToValue(for: provider)
     return .init(publisher.currentValue ?? [], publisher: publisher.map { $0 ?? [] }.eraseToAnyPublisher())
   }
@@ -140,11 +140,11 @@ final class AIModelsManager: AIModelsManagerProtocol {
     try await fetchAndSaveModelsAvailable(for: provider, settings: newSettings)
   }
 
-  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?, Never> {
+  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?> {
     modelsByProviderId.subscribeToValue(for: providerModelId)
   }
 
-  func getModelInfo(by modelId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?, Never> {
+  func getModelInfo(by modelId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?> {
     modelByModelId.subscribeToValue(for: modelId)
   }
 
@@ -445,15 +445,15 @@ extension PublishedDictionary<AIModelID, AIModel> {
 
 extension DefaultLLMService {
 
-  var activeModels: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  var activeModels: ReadonlyCurrentValueSubject<[AIModel]> {
     llmModelsManager.activeModels
   }
 
-  var availableModels: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  var availableModels: ReadonlyCurrentValueSubject<[AIModel]> {
     llmModelsManager.availableModels
   }
 
-  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel], Never> {
+  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel]> {
     llmModelsManager.modelsAvailable(for: provider)
   }
 
@@ -465,15 +465,15 @@ extension DefaultLLMService {
     try await llmModelsManager.refetchModelsAvailable(for: provider, newSettings: newSettings)
   }
 
-  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?, Never> {
+  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?> {
     llmModelsManager.getModel(by: providerModelId)
   }
 
-  func getModelInfo(by modelInfoId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?, Never> {
+  func getModelInfo(by modelInfoId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?> {
     llmModelsManager.getModelInfo(by: modelInfoId)
   }
 
-  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?, Never> {
+  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?> {
     llmModelsManager.provider(for: model)
   }
 
@@ -551,7 +551,7 @@ private final class PublishedDictionary<Key: Hashable & Sendable, Value: Equatab
   var subscribers = [Key: [UUID: @Sendable (Value?) -> Void]]()
   var wrappedValue: [Key: Value]
 
-  func subscribeToValue(for key: Key) -> ReadonlyCurrentValueSubject<Value?, Never> {
+  func subscribeToValue(for key: Key) -> ReadonlyCurrentValueSubject<Value?> {
     let subscriptionId = UUID()
     let publisher = CurrentValueSubject<Value?, Never>(wrappedValue[key])
     let cancellable = AnyCancellable { [weak self] in

--- a/app/modules/services/LLMService/Tests/LLMModelManager+Mock.swift
+++ b/app/modules/services/LLMService/Tests/LLMModelManager+Mock.swift
@@ -16,44 +16,44 @@ final class MockAIModelsManager: AIModelsManagerProtocol {
     setDefaultValues()
   }
 
-  var onModelsAvailableForProvider: @Sendable (AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel], Never> = { _ in
+  var onModelsAvailableForProvider: @Sendable (AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel]> = { _ in
     .just([])
   }
 
   var onRefetchModelsAvailableForProvider: @Sendable (AIProvider, Settings.AIProviderSettings) async throws
     -> [AIProviderModel] = { _, _ in [] }
 
-  var onGetModelByProviderModelId: @Sendable (String) -> ReadonlyCurrentValueSubject<AIProviderModel?, Never> = { _ in
+  var onGetModelByProviderModelId: @Sendable (String) -> ReadonlyCurrentValueSubject<AIProviderModel?> = { _ in
     .just(nil)
   }
 
-  var onGetModelInfoById: @Sendable (AIModelID) -> ReadonlyCurrentValueSubject<AIModel?, Never> = { _ in .just(nil) }
-  var onProviderForModel: @Sendable (AIModel) -> ReadonlyCurrentValueSubject<AIProvider?, Never> = { _ in .just(nil) }
+  var onGetModelInfoById: @Sendable (AIModelID) -> ReadonlyCurrentValueSubject<AIModel?> = { _ in .just(nil) }
+  var onProviderForModel: @Sendable (AIModel) -> ReadonlyCurrentValueSubject<AIProvider?> = { _ in .just(nil) }
 
   let _activeModels: CurrentValueSubject<[AIModel], Never>
   let _availableModels: CurrentValueSubject<[AIModel], Never>
 
-  var availableModels: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  var availableModels: ReadonlyCurrentValueSubject<[AIModel]> {
     _availableModels.readonly()
   }
 
-  var activeModels: ReadonlyCurrentValueSubject<[AIModel], Never> {
+  var activeModels: ReadonlyCurrentValueSubject<[AIModel]> {
     _activeModels.readonly()
   }
 
-  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?, Never> {
+  func provider(for model: AIModel) -> ReadonlyCurrentValueSubject<AIProvider?> {
     onProviderForModel(model)
   }
 
-  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel], Never> {
+  func modelsAvailable(for provider: AIProvider) -> ReadonlyCurrentValueSubject<[AIProviderModel]> {
     onModelsAvailableForProvider(provider)
   }
 
-  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?, Never> {
+  func getModel(by providerModelId: String) -> ReadonlyCurrentValueSubject<AIProviderModel?> {
     onGetModelByProviderModelId(providerModelId)
   }
 
-  func getModelInfo(by modelId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?, Never> {
+  func getModelInfo(by modelId: AIModelID) -> ReadonlyCurrentValueSubject<AIModel?> {
     onGetModelInfoById(modelId)
   }
 

--- a/app/modules/services/MCPService/Sources/DefaultMCPServerConnection.swift
+++ b/app/modules/services/MCPService/Sources/DefaultMCPServerConnection.swift
@@ -73,7 +73,7 @@ final class DefaultMCPServerConnection: MCPServerConnection {
   let serverInfo: ServerInfo
   let configuration: MCPServerConfiguration
 
-  var connectionStatus: ReadonlyCurrentValueSubject<MCPServiceInterface.MCPConnectionStatus, Never> {
+  var connectionStatus: ReadonlyCurrentValueSubject<MCPServiceInterface.MCPConnectionStatus> {
     mutableConnectionStatus.readonly()
   }
 

--- a/app/modules/services/MCPService/Sources/DefaultMCPService.swift
+++ b/app/modules/services/MCPService/Sources/DefaultMCPService.swift
@@ -41,8 +41,8 @@ actor DefaultMCPService: MCPService {
 
   // MARK: - MCPService
 
-  nonisolated var servers: ReadonlyCurrentValueSubject<[MCPServerConnectionStatus], Never> {
-    ReadonlyCurrentValueSubject<[MCPServerConnectionStatus], Never>(
+  nonisolated var servers: ReadonlyCurrentValueSubject<[MCPServerConnectionStatus]> {
+    ReadonlyCurrentValueSubject<[MCPServerConnectionStatus]>(
       Array(_servers.value.values),
       publisher: _servers.map {
         Array($0.values)

--- a/app/modules/services/MCPService/Tests/DefaultMCPServiceTests.swift
+++ b/app/modules/services/MCPService/Tests/DefaultMCPServiceTests.swift
@@ -262,7 +262,7 @@ final class MockMCPServerConnection: MCPServerConnection {
 
   var onDeinit: (@Sendable () -> Void)?
 
-  var connectionStatus: ReadonlyCurrentValueSubject<MCPServiceInterface.MCPConnectionStatus, Never> {
+  var connectionStatus: ReadonlyCurrentValueSubject<MCPServiceInterface.MCPConnectionStatus> {
     mutableConnectionStatus.readonly()
   }
 

--- a/app/modules/services/PermissionsService/Sources/DefaultPermissionService.swift
+++ b/app/modules/services/PermissionsService/Sources/DefaultPermissionService.swift
@@ -48,7 +48,7 @@ final class DefaultPermissionsService: PermissionsService {
     }
   }
 
-  func status(for permission: Permission) -> ReadonlyCurrentValueSubject<Bool?, Never> {
+  func status(for permission: Permission) -> ReadonlyCurrentValueSubject<Bool?> {
     switch permission {
     case .accessibility:
       let isPolling: Bool = inLock { state in

--- a/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
+++ b/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
@@ -71,7 +71,7 @@ final class DefaultSettingsService: SettingsService {
     settings.value[keyPath: keypath]
   }
 
-  func liveValue<T: Equatable>(for keypath: KeyPath<Settings, T>) -> ReadonlyCurrentValueSubject<T, Never> {
+  func liveValue<T: Equatable>(for keypath: KeyPath<Settings, T>) -> ReadonlyCurrentValueSubject<T> {
     ReadonlyCurrentValueSubject(
       settings.value[keyPath: keypath],
       publisher: settings.map { $0[keyPath: keypath] }.removeDuplicates().eraseToAnyPublisher())
@@ -81,7 +81,7 @@ final class DefaultSettingsService: SettingsService {
     settings.value
   }
 
-  func liveValues() -> ReadonlyCurrentValueSubject<Settings, Never> {
+  func liveValues() -> ReadonlyCurrentValueSubject<Settings> {
     settings.readonly(removingDuplicate: true)
   }
 

--- a/app/modules/services/XcodeControllerService/Sources/DefaultXcodeController.swift
+++ b/app/modules/services/XcodeControllerService/Sources/DefaultXcodeController.swift
@@ -29,7 +29,7 @@ final class DefaultXcodeController: XcodeController, Sendable {
     xcodeObserver: XcodeObserver,
     settingsService: SettingsService,
     fileManager: FileManagerI,
-    appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never>)
+    appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState>)
   {
     self.init(
       appEventHandlerRegistry: appEventHandlerRegistry,
@@ -55,7 +55,7 @@ final class DefaultXcodeController: XcodeController, Sendable {
     xcodeObserver: XcodeObserver,
     settingsService: SettingsService,
     fileManager: FileManagerI,
-    appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never>,
+    appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState>,
     timeout: TimeInterval,
     canUseAppleScript: Bool = false,
     startApplyingFileChangeWithXcodeExtension: @escaping @Sendable () async throws -> Void)
@@ -76,7 +76,7 @@ final class DefaultXcodeController: XcodeController, Sendable {
   let shellService: ShellService
   let xcodeObserver: XcodeObserver
   let fileManager: FileManagerI
-  let appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never>
+  let appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState>
 
   #if DEBUG
   var currentExecutionId: String? {
@@ -349,7 +349,7 @@ final class DefaultXcodeController: XcodeController, Sendable {
   private func _getFormattingMetadata() async throws -> FileFormattingMetadata {
     guard appsActivationState.currentValue.isXcodeActive else {
       // If Xcode is not active, we do not want to trigger the extension as this would have the side effect of activating Xcode.
-      // Failing here has no user visibl effect. It just means that the metadata will have to be fetched at a later time.
+      // Failing here has no user visible effect. It just means that the metadata will have to be fetched at a later time.
       throw AppError(message: "Xcode must be active to get formatting metadata")
     }
 

--- a/app/modules/services/XcodeControllerService/Tests/DetaultXcodeControllerTests.swift
+++ b/app/modules/services/XcodeControllerService/Tests/DetaultXcodeControllerTests.swift
@@ -219,7 +219,7 @@ extension DefaultXcodeController {
     xcodeObserver: MockXcodeObserver = MockXcodeObserver(.unknown),
     settingsService: MockSettingsService = MockSettingsService(Settings(pointReleaseXcodeExtensionToDebugApp: false)),
     fileManager: MockFileManager = MockFileManager(),
-    appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never> = .just(.inactive),
+    appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState> = .just(.inactive),
     timeout: TimeInterval = 10,
     startApplyingFileChangeWithXcodeExtension: @escaping @Sendable () async throws -> Void = { })
   {

--- a/app/modules/services/XcodeObserverService/Sources/AppsActivationState.swift
+++ b/app/modules/services/XcodeObserverService/Sources/AppsActivationState.swift
@@ -6,7 +6,7 @@ import DependencyFoundation
 import XcodeObserverServiceInterface
 
 extension BaseProviding where Self: IsHostAppActiveProviding, Self: XcodeObserverProviding {
-  public var appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState, Never> {
+  public var appsActivationState: ReadonlyCurrentValueSubject<AppsActivationState> {
     shared {
       let publisher: AnyPublisher<AppsActivationState, Never> = xcodeObserver.statePublisher
         .compactMap {

--- a/app/modules/services/XcodeObserverService/Sources/DefaultXcodeObserver.swift
+++ b/app/modules/services/XcodeObserverService/Sources/DefaultXcodeObserver.swift
@@ -53,7 +53,7 @@ final class DefaultXcodeObserver: XcodeObserver {
     axNotificationPublisher.eraseToAnyPublisher()
   }
 
-  var statePublisher: ReadonlyCurrentValueSubject<AXState<XcodeState>, Never> {
+  var statePublisher: ReadonlyCurrentValueSubject<AXState<XcodeState>> {
     .init(internalState.value.normalized, publisher: internalState.map(\.normalized).eraseToAnyPublisher())
   }
 

--- a/app/modules/services/XcodeObserverService/Sources/SourceEditorObserver.swift
+++ b/app/modules/services/XcodeObserverService/Sources/SourceEditorObserver.swift
@@ -47,7 +47,7 @@ final class SourceEditorObserver: AXElementObserver, @unchecked Sendable {
 
   let editorElement: AXUIElement
 
-  var state: ReadonlyCurrentValueSubject<InternalXcodeEditorState, Never> {
+  var state: ReadonlyCurrentValueSubject<InternalXcodeEditorState> {
     .init(internalState.value, publisher: internalState.eraseToAnyPublisher())
   }
 

--- a/app/modules/services/XcodeObserverService/Sources/XcodeAppInstanceObserver.swift
+++ b/app/modules/services/XcodeObserverService/Sources/XcodeAppInstanceObserver.swift
@@ -48,7 +48,7 @@ final class XcodeAppInstanceObserver: AXElementObserver, @unchecked Sendable {
 
   let runningApplication: NSRunningApplication
 
-  var state: ReadonlyCurrentValueSubject<InternalXcodeAppState, Never> {
+  var state: ReadonlyCurrentValueSubject<InternalXcodeAppState> {
     .init(internalState.value, publisher: internalState.eraseToAnyPublisher())
   }
 

--- a/app/modules/services/XcodeObserverService/Sources/XcodeWorkspaceObserver.swift
+++ b/app/modules/services/XcodeObserverService/Sources/XcodeWorkspaceObserver.swift
@@ -38,7 +38,7 @@ final class XcodeWorkspaceObserver: AXElementObserver, @unchecked Sendable {
 
   let workspace: AXUIElement
 
-  var state: ReadonlyCurrentValueSubject<InternalXcodeWorkspaceState, Never> {
+  var state: ReadonlyCurrentValueSubject<InternalXcodeWorkspaceState> {
     .init(internalState.value, publisher: internalState.eraseToAnyPublisher())
   }
 


### PR DESCRIPTION
- Fix `ReadonlyCurrentValueSubject` not updating current value
- Also remove error type in `ReadOnlyCurrentValueSubject`, this is different from `CurrentValueSubject`, but simplifies our code