### PR TITLE
Remove disk access from app extension

### DIFF
--- a/app/modules/services/LoggingService/Sources/DefaultLogger.swift
+++ b/app/modules/services/LoggingService/Sources/DefaultLogger.swift
@@ -285,6 +285,7 @@ public final class DefaultLogger: LoggingServiceInterface.Logger {
 
   /// Sets up local file logging with automatic file creation and timestamped naming.
   /// Creates log files in the application support directory under command/logs/.
+  /// Note: File logging is disabled in sandboxed environments (like Xcode extensions).
   /// - Parameters:
   ///   - writeToFile: Optional custom file writing function
   ///   - fileManager: File manager for handling file operations
@@ -292,6 +293,12 @@ public final class DefaultLogger: LoggingServiceInterface.Logger {
     if let writeToFile {
       self.writeToFile = writeToFile
     } else {
+      // Skip file logging in sandboxed environments (like Xcode extensions)
+      // Sandboxed processes can still log to the console via os.Logger, but cannot write log files
+      guard Bundle.main.isHostApp else {
+        return
+      }
+
       let dateFormatter = DateFormatter()
       dateFormatter.dateFormat = "yyyy-MM-dd__HH-mm-ss.SSS"
       dateFormatter.timeZone = TimeZone(abbreviation: "UTC")

--- a/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
+++ b/app/modules/services/SettingsService/Sources/DefaultSettingsService.swift
@@ -28,9 +28,18 @@ final class DefaultSettingsService: SettingsService {
     releaseSharedUserDefaults: UserDefaultsI?,
     bundle: Bundle = .main)
   {
+    // Sandboxed processes (like the Xcode extension) cannot access the home directory.
+    // They read settings from UserDefaults instead, so settingsFileLocation is nil.
+    let settingsFileLocation: URL? =
+      if bundle.isHostApp {
+        fileManager.homeDirectoryForCurrentUser.appending(path: ".cmd/settings.json")
+      } else {
+        nil
+      }
+
     self.init(
       fileManager: fileManager,
-      settingsFileLocation: fileManager.homeDirectoryForCurrentUser.appending(path: ".cmd/settings.json"),
+      settingsFileLocation: settingsFileLocation,
       sharedUserDefaults: sharedUserDefaults,
       releaseSharedUserDefaults: releaseSharedUserDefaults,
       bundle: bundle)
@@ -38,7 +47,7 @@ final class DefaultSettingsService: SettingsService {
 
   init(
     fileManager: FileManagerI,
-    settingsFileLocation: URL,
+    settingsFileLocation: URL?,
     sharedUserDefaults: UserDefaultsI,
     releaseSharedUserDefaults: UserDefaultsI?,
     bundle: Bundle = .main)
@@ -119,7 +128,7 @@ final class DefaultSettingsService: SettingsService {
   private var notificationObserver: AnyCancellable?
 
   private let fileManager: FileManagerI
-  private let settingsFileLocation: URL
+  private let settingsFileLocation: URL?
   private let sharedUserDefaults: UserDefaultsI
   private let releaseSharedUserDefaults: UserDefaultsI?
   /// Whether the notification for updates from user defaults should be skipped.
@@ -148,7 +157,7 @@ final class DefaultSettingsService: SettingsService {
       .bool(forKey: SharedKeys.pointReleaseXcodeExtensionToDebugApp)
 
     let data: Data? =
-      if bundle.isHostApp {
+      if bundle.isHostApp, let settingsFileLocation {
         try? fileManager.read(dataFrom: settingsFileLocation)
       } else {
         // The Xcode extension is sandboxed and cannot read the settings from disk. It reads a copy written to user defaults.
@@ -169,7 +178,7 @@ final class DefaultSettingsService: SettingsService {
         }
       } ??? .defaultSettings
 
-    if let data {
+    if bundle.isHostApp, let data {
       saveSettingsForSandboxedProcesses(data)
     }
 
@@ -279,9 +288,10 @@ final class DefaultSettingsService: SettingsService {
     let internalSettings = try JSONEncoder.sortingKeys.encode(publicSettings.internalSettings())
     sharedUserDefaults.set(internalSettings, forKey: Keys.internalSettings)
 
-    // External settings are written to json files at known locations, that can easily be edited by users.
     let externalSettings = publicSettings.externalSettings
-    try externalSettings.writeNonDefaultValues(to: settingsFileLocation, fileManager: fileManager)
+    if let settingsFileLocation {
+      try externalSettings.writeNonDefaultValues(to: settingsFileLocation, fileManager: fileManager)
+    }
     saveSettingsForSandboxedProcesses(externalSettings)
 
     // Store this value separately in user defaults, as it can also be accessed by the release version.


### PR DESCRIPTION
This had no user impact, but would show error logs