### PR TITLE
Revert "disable CI cache that github broke"

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -47,6 +47,11 @@ jobs:
           npm install --global @bugsnag/cli
           brew install graphicsmagick imagemagick sentry-cli
           cd app/fastlane && gem install bundler && bundle install
+      - name: Load derived data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: app/build/derived_data
+          key: ${{ runner.os }}-app-derived-data-main
       - name: Build and sign release
         run: cd app/fastlane && bundle exec fastlane mac build_artifact
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,6 +61,17 @@ jobs:
         with:
           swift-version: "6.2"
           soft-fail-version-check: true
+      - name: Restore SPM cache
+        uses: actions/cache/restore@v4
+        with:
+          path: app/tools/dependencies/.build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages/
+          key: ${{ runner.os }}_spm_dependencies_tool_${{ hashFiles('app/tools/dependencies/Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}_spm_dependencies_tool_main
+            ${{ runner.os }}_spm_dependencies_tool_
       - name: Run app tools tests
         run: cd app/tools/dependencies && swift test
 
@@ -101,6 +112,14 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install swiftformat
         run: brew install swiftformat
+      - name: Restore dependencies binary cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cmd/dev/tmp/bin/sync-package-dependencies
+          key: ${{ runner.os }}_spm_tools_${{ hashFiles('app/tools/dependencies/**') }}
+          restore-keys: |
+            ${{ runner.os }}_spm_tools_main
+            ${{ runner.os }}_spm_tools_
       - name: Run sync dependencies
         run: ./cmd.sh sync:dependencies
       - name: Verify that `cmd sync:dependencies` did not change outputs (if it did, please re-run it and re-commit!)
@@ -120,6 +139,14 @@ jobs:
           node-version-file: "./local-server/.nvmrc"
       - name: Enable Corepack
         run: corepack enable
+      - name: Restore npm cache
+        uses: actions/cache/restore@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}_npm_modules_main
+            ${{ runner.os }}_npm_modules_
       - name: Install dependencies
         run: cd local-server && yarn install
       - name: Run tests
@@ -139,6 +166,14 @@ jobs:
           node-version-file: "./local-server/.nvmrc"
       - name: Enable Corepack
         run: corepack enable
+      - name: Restore npm cache
+        uses: actions/cache/restore@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}_npm_modules_main
+            ${{ runner.os }}_npm_modules_
       - name: Install dependencies
         run: cd local-server && yarn install
       - name: Run tests
@@ -158,6 +193,14 @@ jobs:
           node-version-file: "./local-server/.nvmrc"
       - name: Enable Corepack
         run: corepack enable
+      - name: Restore npm cache
+        uses: actions/cache/restore@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}_npm_modules_main
+            ${{ runner.os }}_npm_modules_
       - name: Install dependencies
         run: cd local-server && yarn install
       - name: Run linter

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -42,6 +42,11 @@ jobs:
           npm install --global @bugsnag/cli
           brew install graphicsmagick imagemagick sentry-cli
           cd app/fastlane && gem install bundler && bundle install
+      - name: Load derived data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: app/build/derived_data
+          key: ${{ runner.os }}-app-derived-data-main
       - name: Publish release
         run: cd app/fastlane && bundle exec fastlane mac distribute_release next:true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
           node-version-file: "./local-server/.nvmrc"
       - name: Enable Corepack
         run: corepack enable
+      - name: Load npm cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
       - name: Install node dependencies
         run: cd local-server && yarn install && yarn build && yarn copy-to-app
       # See https://github.com/actions/runner-images/issues/10722#issuecomment-2387952421
@@ -42,6 +48,25 @@ jobs:
           npm install --global @bugsnag/cli
           brew install graphicsmagick imagemagick sentry-cli
           cd app/fastlane && gem install bundler && bundle install
+      - name: Load SPM packages cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}_spm_packages_
+      - name: Load release build cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache@v4
+        with:
+          path: app/build/derived_data
+          key: ${{ runner.os }}_release_build_${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}_release_build_main
+            ${{ runner.os }}_release_build_
       - name: Publish release
         run: cd app/fastlane && bundle exec fastlane mac distribute_release
         env:

--- a/.github/workflows/reusable-build-release-app.yml
+++ b/.github/workflows/reusable-build-release-app.yml
@@ -28,6 +28,14 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26.0"
+      - name: Restore npm cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache/restore@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}_npm_modules_
       - name: Install node dependencies
         run: cd local-server && yarn install && yarn build && yarn copy-to-app
       # See https://github.com/actions/runner-images/issues/10722#issuecomment-2387952421
@@ -36,6 +44,27 @@ jobs:
           machine: github.com
           username: oauth2
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Restore SPM packages cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}_spm_packages_
+      - name: Restore release build cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache/restore@v4
+        with:
+          path: app/build/derived_data
+          key: ${{ runner.os }}_release_build_${{ hashFiles('app/**') }}
+          restore-keys: |
+            ${{ runner.os }}_release_build_
+      # If more Xcode specific issues arise with caching, consider the less used 3rd party https://github.com/irgaly/xcode-cache
+      - name: Clean module cache to prevent timestamp mismatches
+        run: rm -rf app/build/derived_data/ModuleCache.noindex
       - name: Install fastlane dependencies
         run: |
           cd app/fastlane && gem install bundler && bundle install
@@ -65,3 +94,23 @@ jobs:
             echo "✗ Expected MACOSX_DEPLOYMENT_TARGET to be 15.0, but found: `$deployment_target`"
             exit 1
           fi
+      - name: Save release build cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: app/build/derived_data
+          key: ${{ runner.os }}_release_build_${{ hashFiles('app/**') }}
+      - name: Save SPM packages cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
+      - name: Save npm cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}

--- a/.github/workflows/reusable-test-swift-app.yml
+++ b/.github/workflows/reusable-test-swift-app.yml
@@ -28,7 +28,51 @@ jobs:
           node-version-file: "./local-server/.nvmrc"
       - name: Enable Corepack
         run: corepack enable
+      - name: Restore npm cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache/restore@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}_npm_modules_
       - name: Install dependencies
         run: cd local-server && yarn install && yarn build && yarn copy-to-app
+      - name: Restore SPM cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}_spm_packages_
+      - name: Restore modules build cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache/restore@v4
+        with:
+          path: app/modules/.build
+          key: ${{ runner.os }}_modules_build_${{ hashFiles('app/modules/**') }}
+          restore-keys: |
+            ${{ runner.os }}_modules_build_
       - name: Run app module tests
         run: ./cmd.sh test:swift
+      - name: Save modules build cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: app/modules/.build
+          key: ${{ runner.os }}_modules_build_${{ hashFiles('app/modules/**') }}
+      - name: Save SPM cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: ${{ runner.os }}_spm_packages_${{ hashFiles('app/modules/Package.resolved') }}
+      - name: Save npm cache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: local-server/node_modules
+          key: ${{ runner.os }}_npm_modules_${{ hashFiles('local-server/yarn.lock') }}


### PR DESCRIPTION
This reverts commit b87edfbfb5290099b74fe964f963c716114740df.

Github seems to have fixed their macOS image: https://github.com/actions/runner/issues/4134